### PR TITLE
Add support to parse strings and multiple times

### DIFF
--- a/qasm_flex_bison/library/qasm_semantic.hpp
+++ b/qasm_flex_bison/library/qasm_semantic.hpp
@@ -10,6 +10,7 @@ extern int yyparse();
 extern int yylex();
 extern FILE* yyin;
 extern struct YY_BUFFER_STATE* yy_scan_string(const char*);
+extern int yylex_destroy(void);
 extern compiler::QasmRepresentation qasm_representation;
 
 namespace compiler
@@ -19,6 +20,9 @@ namespace compiler
         public:
             QasmSemanticChecker(const char* qasm_str)
             {
+                // Clean state
+                yylex_destroy();
+
                 // set lex to read from it instead of defaulting to STDIN:
                 yy_scan_string(qasm_str);
 
@@ -33,6 +37,9 @@ namespace compiler
 
             QasmSemanticChecker(FILE *qasm_file)
             {
+                // Clean state
+                yylex_destroy();
+
                 // set lex to read from it instead of defaulting to STDIN:
                 yyin = qasm_file;
 


### PR DESCRIPTION
This PR adds the following features:

- Currently the only way to parse cQASM code is by storing it in a `file`. This PR adds support to also parse `strings` of cQASM.

- If the user of `libqasm` wants to parse multiple files in one execution, the parser needs to be reset. This PR cleans the state of the previous parsing before the next one.