### PR TITLE
fix for stateful behavriour

### DIFF
--- a/qasm_flex_bison/library/qasm_ast.hpp
+++ b/qasm_flex_bison/library/qasm_ast.hpp
@@ -586,6 +586,8 @@ namespace compiler
                 return subcircuits_;
             }
 
+            void clearSubCircuits() { subcircuits_.clear(); }
+
         protected:
             std::vector<SubCircuit> subcircuits_;
     }; //class SubCircuits

--- a/qasm_flex_bison/library/qasm_semantic.hpp
+++ b/qasm_flex_bison/library/qasm_semantic.hpp
@@ -10,6 +10,7 @@ extern int yyparse();
 extern int yylex();
 extern FILE* yyin;
 extern compiler::QasmRepresentation qasm_representation;
+extern compiler::SubCircuits subcircuits_object;
 
 namespace compiler
 {
@@ -35,6 +36,8 @@ namespace compiler
                 result = doChecks();
                 parse_result_ = result;
             }
+
+            ~QasmSemanticChecker() { subcircuits_object.clearSubCircuits(); }
 
             int parseResult() const
             {


### PR DESCRIPTION
The globaly declared `compiler::SubCircuits subcircuits_object` is now cleared in destructor.