### PR TITLE
Added skip n as copy of wait n, but meaning to not issue bundles in n…

### DIFF
--- a/src/library/grammar.y
+++ b/src/library/grammar.y
@@ -52,7 +52,7 @@
 %token <sval> SINGLE_QUBIT_GATES TWO_QUBIT_GATES CR CRK TOFFOLI
 %token <sval> CDASH NOT_TOKEN
 %token <sval> MAPKEY PREP MEASURE MEASUREPARITY MEASUREALL
-%token <sval> WAIT DISPLAY RESET_AVERAGING LOAD_STATE QUOTED_STRING
+%token <sval> SKIP WAIT DISPLAY RESET_AVERAGING LOAD_STATE QUOTED_STRING
 %token <sval> ERROR_MODEL_KEY ERROR_MODEL
 %token QBITHEAD BITHEAD
 
@@ -419,8 +419,8 @@ parallelizable-ops : all-valid-operations
     ;
 
 //# Special operations
-%type <oval> special-operations display-operation wait-operation reset-averaging-operation load-state-operation;
-special-operations : display-operation | wait-operation | reset-averaging-operation | load-state-operation
+%type <oval> special-operations display-operation skip-operation wait-operation reset-averaging-operation load-state-operation;
+special-operations : display-operation | skip-operation | wait-operation | reset-averaging-operation | load-state-operation
     ;
 display-operation : DISPLAY NEWLINE
                     {
@@ -434,6 +434,11 @@ display-operation : DISPLAY NEWLINE
                     {
                         $$ = new compiler::Operation( std::string($1), *($3) );
                     }
+    ;
+skip-operation : SKIP WS INTEGER
+                 {
+                     $$ = new compiler::Operation( std::string($1,4), ($3) );
+                 }
     ;
 wait-operation : WAIT WS INTEGER
                  {

--- a/src/library/lex.l
+++ b/src/library/lex.l
@@ -52,6 +52,7 @@ comma_sep          {whitespace}?,{whitespace}?
 parallel_sep       {whitespace}?\|{whitespace}?
 qubits             (?i:qubits)
 mapkey             (?i:map)
+skip               (?i:skip)
 wait               (?i:wait)
 resetavg           (?i:reset-averaging)
 display            ((?i:display)|(?i:display_binary))
@@ -110,6 +111,8 @@ qasm_version       (?i:version)
 {measureparity} TOKENSTR(MEASUREPARITY)
 
 {display} TOKENSTR(DISPLAY)
+
+{skip} TOKENSTR(SKIP)
 
 {wait} TOKENSTR(WAIT)
 

--- a/src/library/qasm_ast.hpp
+++ b/src/library/qasm_ast.hpp
@@ -156,7 +156,7 @@ namespace compiler
 
             Operation(const std::string type, const int waitInt)
             : rotation_angle_ (std::numeric_limits<double>::max()), bit_controlled_(false)
-            // Wait command
+            // Wait and Skip commands
             {
                 type_ = toLowerCase(type);
                 wait_time_ = waitInt;
@@ -357,6 +357,11 @@ namespace compiler
                     getToffoliQubitPairs().second.first.printMembers();
                     std::cout << "Qubit Pair 3: ";
                     getToffoliQubitPairs().second.second.printMembers();
+                }
+                else if (type_ == "skip")
+                {
+                    std::cout << std::endl;
+                    std::cout << "Wait time (integer) = " << getWaitTime() << std::endl;
                 }
                 else if (type_ == "wait")
                 {

--- a/src/library/qasm_semantic.hpp
+++ b/src/library/qasm_semantic.hpp
@@ -145,7 +145,7 @@ namespace compiler
                 {
                     result = checkResetAveraging(op, linenumber);
                 }
-                else if (type_ == "wait" || type_ == "display" || type_ == "display_binary" || type_ == "not" || type_ == "load_state")
+                else if (type_ == "skip" || type_ == "wait" || type_ == "display" || type_ == "display_binary" || type_ == "not" || type_ == "load_state")
                 {
                     result = checkWaitDisplayNot(op, linenumber);
                 }


### PR DESCRIPTION
Added skip n with n number of cycles, in syntax similar to wait n.
In the bundled representation of qasm, each line/bundle specifies
the instructions/gates that should start in one cycle.
Subsequent lines/bundles represent instructions/gates of subsequent cycles.
Instead of a bundle, the line can contain skip n, with n a number of cycles >= 1.
Meaning of skip n is to insert n cycles in which no instructions/bundles are started.
It is short for inserting n empty lines.

It was added because the current wait n is interpreted by the OpenQL compiler differently:
it means (standalone on a line) that execution should be scheduled such that all gates that
are still executing, complete before 'executing' the wait n; this is the barrier part of wait.
And that subsequently, there will be n cycles in which no gate is executing (so also not
in parallel).
And after that, the gates can be started that follow the wait n.
So wait n is a scheduling directive with a barrier semantics.

In an accompanying update, the OpenQL compiler will print skip n between bundles
instead of wait n when a skip n is intended.
And the cqasm reader will accept a skip n from libqasm and in an initial implementation
do nothing with it.
A later implementation of cqasm reader may use skip to support in setting the cycle
attributes of the created gates.