### PR TITLE
Fix setup.py failing when invoked by pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,14 +93,14 @@ def build_libqasm_library(make_command: str, test_command: str, cmake_options: s
         cmake_options: additional build options to pass to cmake.
     """
     os.chdir(build_dir)
-    execute_process(f'git submodule update --init --recursive')
+    execute_process(f'git submodule update --init --recursive', allow_failure=True)
     execute_process(f'cmake {cmake_options} {os.path.join("..", "library")}')
     execute_process(f'{make_command}')
     execute_process(f'{test_command}')
     os.chdir(root_dir)
 
 
-def execute_process(command: str) -> None:
+def execute_process(command: str, allow_failure: bool=False) -> None:
     """Execute shell commands.
 
     Args:
@@ -108,7 +108,7 @@ def execute_process(command: str) -> None:
     """
     proc = subprocess.Popen(command, shell=True)
     proc.communicate()
-    if proc.returncode:
+    if proc.returncode and not allow_failure:
         raise RuntimeError('process failed')
 
 


### PR DESCRIPTION
pip does some magic to copy the source tree into a temporary directory for the build. Apparently it's "smart enough" to skip the .git folder. setup.py insists on running `git submodule update --init --recursive` however, which thus fails. I must have broken this in 3b54ae8b by adding the return code check and apparently didn't check `pip install .` afterwards.

I noticed it a few days ago when I merged develop into the OpenQL test branch, which now apparently does `pip install .` in CI for libqasm, but didn't want to add it to the big PR while it was frozen for review.