### PR TITLE
Improve release/readme, make PyPI package name lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 
 # libQASM: Library to parse cQASM v1.0 files
 
+[![CI](https://github.com/QE-Lab/libqasm/workflows/Test/badge.svg)](https://github.com/qe-lab/libqasm/actions)
+[![PyPI](https://badgen.net/pypi/v/libQasm)](https://pypi.org/project/libQasm/)
+[![API docs](https://readthedocs.org/projects/libqasm/badge/?version=latest)](https://libqasm.readthedocs.io/en/latest/)
+
 ## Dependencies
 * Flex (> 2.6)
 * Bison (> 3.0)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,11 +7,12 @@ packages for all platform, and publish them to PyPI and conda assuming the
 secrets are configured correctly.
 
  - Make a branch with a name starting with "release" based upon the commit that
-   is to be released.
+   is to be released. For example, `release-0.0.1`, but the suffix doesn't
+   matter.
 
- - Change the version in `src/version.h` (everything else that needs a version
-   should derive from this) and change any other files where applicable
-   (changelog, etc), then commit and make a PR for it.
+ - Change the version in `setup.py` (this is the only place where the version
+   is hardcoded) and change any other files where applicable (changelog, etc),
+   then commit and make a PR for it.
 
  - CI will now run not only the test workflow, but also the assets workflow.
    The assets workflow builds the wheels and conda packages, but publishes them
@@ -23,9 +24,12 @@ secrets are configured correctly.
  - If the test or assets workflows fail, fix it before merging the PR (of
    course).
 
- - Once CI is green, merge the PR and delete the branch. Instead, push a
-   tag with the appropriate version (customarily `x.y.z` without a `v` in
-   front).
+ - Once CI is green, merge the PR into `develop` if there are any changes.
+   If no changes were needed, just delete the branch to clean up.
+
+ - Push a tag with the appropriate version (customarily `x.y.z` without a `v`
+   in front) for the latest version of `develop` (if the PR had changes and
+   was merged, be sure to pull the changes first).
 
  - CI will automatically make a complete GitHub release for your tag. It will
    then run the assets workflow again, now with the new version string baked

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ class egg_info(_egg_info):
         self.egg_base = os.path.relpath(target_dir)
 
 setup(
-    name='libQasm',
+    name='libqasm',
     version=get_version(),
     description='libQasm Python Package',
     long_description=read('README.md'),


### PR DESCRIPTION
 - Update/fix `RELEASE.md` per Razvan's comments in #107.
 - Add badges to `README.md`
 - Use `libqasm` for the PyPI package rather than `libQasm` per convention (PyPI might reject it now or later otherwise)