### PR TITLE
Add new syntax for conditional gate

### DIFF
--- a/src/cqasm/src/cqasm-lexer.l
+++ b/src/cqasm/src/cqasm-lexer.l
@@ -110,6 +110,9 @@
     /* C-dash prefix for binary-controlled gates */
 [cC]-/[a-zA-Z_]                                     WITHOUT_STR(CDASH);
 
+    /* New-style binary-controlled gate syntax */
+(?i:cond)                                           WITHOUT_STR(COND);
+
     /* Absolute nonsense for compatibility purposes: the reset-averaging */
     /* operation has a - in it, which is not legal in an identifier for */
     /* obvious reasons when expressions come along. */

--- a/src/cqasm/src/cqasm-parser.y
+++ b/src/cqasm/src/cqasm-parser.y
@@ -138,6 +138,7 @@
 %token QUBITS
 %token MAP
 %token CDASH
+%token COND
 
 /* Numeric literals */
 %token <str> INT_LITERAL
@@ -296,6 +297,7 @@ Instruction     : Identifier                                                    
                 | Identifier ExpressionList                                     { NEW($$, Instruction); $$->name.set_raw($1); $$->operands.set_raw($2); }
                 | CDASH Identifier Expression                                   { NEW($$, Instruction); $$->name.set_raw($2); $$->condition.set_raw($3); $$->operands.set_raw(new ExpressionList()); }
                 | CDASH Identifier Expression ',' ExpressionList                { NEW($$, Instruction); $$->name.set_raw($2); $$->condition.set_raw($3); $$->operands.set_raw($5); }
+                | COND '(' Expression ')' Identifier ExpressionList             { NEW($$, Instruction); $$->name.set_raw($5); $$->condition.set_raw($3); $$->operands.set_raw($6); }
                 ;
 
 /* Instructions are not statements (because there can be multiple bundled

--- a/src/cqasm/tests/parsing/semantic/insn-condition-new-ok/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-new-ok/ast.golden.txt
@@ -1,0 +1,91 @@
+SUCCESS
+Program( # input.cq:1:1..6:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: <
+    IntegerLiteral( # input.cq:2:8..10
+      value: 10
+    )
+  >
+  statements: <
+    StatementList( # input.cq:5:1..23
+      items: [
+        Bundle( # input.cq:5:1..23
+          items: [
+            Instruction( # input.cq:5:1..23
+              name: <
+                Identifier( # input.cq:5:15..16
+                  name: x
+                )
+              >
+              condition: <
+                Index( # input.cq:5:7..13
+                  expr: <
+                    Identifier( # input.cq:5:7..8
+                      name: b
+                    )
+                  >
+                  indices: <
+                    IndexList( # input.cq:5:9..12
+                      items: [
+                        IndexRange( # input.cq:5:9..12
+                          first: <
+                            IntegerLiteral( # input.cq:5:9..10
+                              value: 0
+                            )
+                          >
+                          last: <
+                            IntegerLiteral( # input.cq:5:11..12
+                              value: 3
+                            )
+                          >
+                        )
+                      ]
+                    )
+                  >
+                )
+              >
+              operands: <
+                ExpressionList( # input.cq:5:17..23
+                  items: [
+                    Index( # input.cq:5:17..23
+                      expr: <
+                        Identifier( # input.cq:5:17..18
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:5:19..22
+                          items: [
+                            IndexRange( # input.cq:5:19..22
+                              first: <
+                                IntegerLiteral( # input.cq:5:19..20
+                                  value: 4
+                                )
+                              >
+                              last: <
+                                IntegerLiteral( # input.cq:5:21..22
+                                  value: 5
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/src/cqasm/tests/parsing/semantic/insn-condition-new-ok/input.cq
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-new-ok/input.cq
@@ -1,0 +1,5 @@
+version 1.0
+qubits 10
+
+# note; differening lengths between condition and parameters are allowed
+cond (b[0:3]) x q[4:5]

--- a/src/cqasm/tests/parsing/semantic/insn-condition-new-ok/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-new-ok/semantic.golden.txt
@@ -1,0 +1,61 @@
+SUCCESS
+Program( # input.cq:1:1..6:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: 10
+  error_model: -
+  subcircuits: [
+    Subcircuit( # input.cq:5:1..23
+      name: 
+      iterations: 1
+      bundles: [
+        Bundle( # input.cq:5:1..23
+          items: [
+            Instruction( # input.cq:5:1..23
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                BitRefs( # input.cq:5:7..13
+                  index: [
+                    ConstInt( # input.cq:5:9..12
+                      value: 0
+                    )
+                    ConstInt( # input.cq:5:9..12
+                      value: 1
+                    )
+                    ConstInt( # input.cq:5:9..12
+                      value: 2
+                    )
+                    ConstInt( # input.cq:5:9..12
+                      value: 3
+                    )
+                  ]
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:5:17..23
+                  index: [
+                    ConstInt( # input.cq:5:19..22
+                      value: 4
+                    )
+                    ConstInt( # input.cq:5:19..22
+                      value: 5
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+      annotations: []
+    )
+  ]
+  mappings: []
+)
+


### PR DESCRIPTION
This adds additional syntax for specifying conditional gates, as agreed upon within the context of work package 15. The old syntax was found to be confusing, leading people to believe that gates prefixed `c-` were semantically different gates as far as libqasm is concerned. The new syntax is:

```
cond (<condition>) <gate> <gate args>
```

This is entirely semantically equivalent to:

```
c-<gate> <condition>, <gate args>
```

It mimics a one-line `if` statement in C, but uses `cond` instead of `if` to reserve `if` for control-flow `if` statements later.

Aside from the new keyword (`cond`), this does not break anything. The old syntax is still supported.