### PR TITLE
Dynamic expression support

### DIFF
--- a/src/cqasm/func-gen/func-gen.cpp
+++ b/src/cqasm/func-gen/func-gen.cpp
@@ -324,28 +324,28 @@ int main(int argc, char *argv[]) {
     func_gen::Generator generator{argv[1], argv[2]};
 
     // Basic scalar operators.
-    generator.generate_const_scalar_op("operator+", 'i', "ii", "a + b");
-    generator.generate_const_scalar_op("operator+", 'r', "rr", "a + b");
     generator.generate_const_scalar_op("operator+", 'c', "cc", "a + b");
+    generator.generate_const_scalar_op("operator+", 'r', "rr", "a + b");
+    generator.generate_const_scalar_op("operator+", 'i', "ii", "a + b");
     generator.generate_const_scalar_op("operator+", 's', "ss", "a + b");
-    generator.generate_const_scalar_op("operator-", 'i', "ii", "a - b");
-    generator.generate_const_scalar_op("operator-", 'r', "rr", "a - b");
     generator.generate_const_scalar_op("operator-", 'c', "cc", "a - b");
-    generator.generate_const_scalar_op("operator-", 'i', "i", "-a");
-    generator.generate_const_scalar_op("operator-", 'r', "r", "-a");
+    generator.generate_const_scalar_op("operator-", 'r', "rr", "a - b");
+    generator.generate_const_scalar_op("operator-", 'i', "ii", "a - b");
     generator.generate_const_scalar_op("operator-", 'c', "c", "-a");
-    generator.generate_const_scalar_op("operator*", 'i', "ii", "a * b");
-    generator.generate_const_scalar_op("operator*", 'r', "rr", "a * b");
+    generator.generate_const_scalar_op("operator-", 'r', "r", "-a");
+    generator.generate_const_scalar_op("operator-", 'i', "i", "-a");
     generator.generate_const_scalar_op("operator*", 'c', "cc", "a * b");
-    generator.generate_const_scalar_op("operator/", 'r', "ii", "(double)a / (double)b");
-    generator.generate_const_scalar_op("operator/", 'r', "rr", "a / b");
+    generator.generate_const_scalar_op("operator*", 'r', "rr", "a * b");
+    generator.generate_const_scalar_op("operator*", 'i', "ii", "a * b");
     generator.generate_const_scalar_op("operator/", 'c', "cc", "a / b");
-    generator.generate_const_scalar_op("operator**", 'r', "rr", "std::pow(a, b)");
+    generator.generate_const_scalar_op("operator/", 'r', "rr", "a / b");
+    generator.generate_const_scalar_op("operator/", 'r', "ii", "(double)a / (double)b");
     generator.generate_const_scalar_op("operator**", 'c', "cc", "std::pow(a, b)");
+    generator.generate_const_scalar_op("operator**", 'r', "rr", "std::pow(a, b)");
 
     // Scalar root, exponent, and trigonometric functions for reals and complex
     // numbers.
-    for (const char *type : {"r", "c"}) {
+    for (const char *type : {"c", "r"}) {
         generator.generate_const_scalar_op("sqrt", type[0], type, "std::sqrt(a)");
         generator.generate_const_scalar_op("exp", type[0], type, "std::exp(a)");
         generator.generate_const_scalar_op("log", type[0], type, "std::log(a)");
@@ -362,8 +362,8 @@ int main(int argc, char *argv[]) {
     }
 
     // Absolute value function.
-    generator.generate_const_scalar_op("abs", 'i', "i", "std::abs(a)");
     generator.generate_const_scalar_op("abs", 'r', "r", "std::abs(a)");
+    generator.generate_const_scalar_op("abs", 'i', "i", "std::abs(a)");
 
     // Complex number manipulation functions.
     generator.generate_const_scalar_op("complex", 'c', "rr", "primitives::Complex(a, b)");

--- a/src/cqasm/include/cqasm-analyzer.hpp
+++ b/src/cqasm/include/cqasm-analyzer.hpp
@@ -165,6 +165,14 @@ public:
 
     /**
      * Registers a function, usable within expressions.
+     *
+     * values::check_const() can be used in the function implementation to
+     * assert that the values must be constant when the function can only be
+     * used during constant propagation. When the function also (or only)
+     * supports dynamic evaluation, the implementation will have to check
+     * whether the inputs are const manually (for instance using
+     * `as_constant()`) to determine when to return a dynamic values::Function
+     * node instead.
      */
     void register_function(
         const std::string &name,

--- a/src/cqasm/include/cqasm-resolver.hpp
+++ b/src/cqasm/include/cqasm-resolver.hpp
@@ -95,6 +95,11 @@ public:
      * expects. The C++ implementation of the function can assume that the
      * value list it gets is of the right size and the values are of the right
      * types.
+     *
+     * This method does not contain any intelligence to override previously
+     * added overloads. However, the overload resolution engine will always use
+     * the last applicable overload it finds, so adding does have the effect of
+     * overriding.
      */
     void add(const std::string &name, const types::Types &param_types, const FunctionImpl &impl);
 

--- a/src/cqasm/include/cqasm-types.hpp
+++ b/src/cqasm/include/cqasm-types.hpp
@@ -49,6 +49,12 @@ using Types = tree::Any<TypeBase>;
  */
 Types from_spec(const std::string &spec);
 
+/**
+ * Returns whether the `actual` type matches the constraints of the `expected`
+ * type.
+ */
+bool type_check(const Type &expected, const Type &actual);
+
 } // namespace types
 } // namespace cqasm
 

--- a/src/cqasm/include/cqasm-values.hpp
+++ b/src/cqasm/include/cqasm-values.hpp
@@ -31,8 +31,10 @@ using Values = tree::Any<Node>;
 
 /**
  * Type-checks and (if necessary) promotes the given value to the given type.
- * Returns null if the check/promotion fails, otherwise returns the constructed
- * value by way of a smart pointer.
+ * Also checks assignability of the value if the type says the value must be
+ * assignable. Returns null if the check/promotion fails, otherwise returns the
+ * constructed value by way of a smart pointer. If the type was an exact match,
+ * this may return the given value without modification or a clone thereof.
  */
 Value promote(const Value &value, const types::Type &type);
 

--- a/src/cqasm/src/cqasm-types.cpp
+++ b/src/cqasm/src/cqasm-types.cpp
@@ -89,6 +89,53 @@ Types from_spec(const std::string &spec) {
     return types;
 }
 
+/**
+ * Returns whether the `actual` type matches the constraints of the `expected`
+ * type.
+ */
+bool type_check(const Type &expected, const Type &actual) {
+
+    // Check assignability constraint.
+    if (expected->assignable && !actual->assignable) {
+        return false;
+    }
+
+    // Check the type itself.
+    if (actual->type() != expected->type()) {
+        return false;
+    }
+
+    // Check matrix constraints if applicable.
+    if (auto expected_real_mat = expected->as_real_matrix()) {
+        auto actual_mat = actual->as_real_matrix();
+        if (expected_real_mat->num_cols >= 0) {
+            if (actual_mat->num_cols != expected_real_mat->num_cols) {
+                return false;
+            }
+        }
+        if (expected_real_mat->num_rows >= 0) {
+            if (actual_mat->num_rows != expected_real_mat->num_rows) {
+                return false;
+            }
+        }
+    } else if (auto expected_complex_mat = expected->as_complex_matrix()) {
+        auto actual_mat = actual->as_complex_matrix();
+        if (expected_complex_mat->num_cols >= 0) {
+            if (actual_mat->num_cols != expected_complex_mat->num_cols) {
+                return false;
+            }
+        }
+        if (expected_complex_mat->num_rows >= 0) {
+            if (actual_mat->num_rows != expected_complex_mat->num_rows) {
+                return false;
+            }
+        }
+    }
+
+    // All constraints seem to match.
+    return true;
+}
+
 } // namespace types
 } // namespace cqasm
 

--- a/src/cqasm/src/cqasm-values.cpp
+++ b/src/cqasm/src/cqasm-values.cpp
@@ -4,6 +4,7 @@
 
 #include <cqasm-parse-helper.hpp>
 #include "cqasm-values.hpp"
+#include "cqasm-types.hpp"
 #include "cqasm-error.hpp"
 
 namespace cqasm {
@@ -16,161 +17,82 @@ using ValueEnum = values::NodeType;
  * Type-checks and (if necessary) promotes the given value to the given type.
  * Also checks assignability of the value if the type says the value must be
  * assignable. Returns null if the check/promotion fails, otherwise returns the
- * constructed value by way of a smart pointer.
+ * constructed value by way of a smart pointer. If the type was an exact match,
+ * this may return the given value without modification or a clone thereof.
  */
 Value promote(const Value &value, const types::Type &type) {
-    Value retval;
-    switch (type->type()) {
-        case TypeEnum::Qubit:
-            if (auto qubit_refs = value->as_qubit_refs()) {
-                retval = tree::make<values::QubitRefs>(*qubit_refs);
-            }
-            break;
 
-        case TypeEnum::Bool:
-            if (auto bit_refs = value->as_bit_refs()) {
-                retval = tree::make<values::BitRefs>(*bit_refs);
-            } else if (auto const_bool = value->as_const_bool()) {
-                if (!type->assignable) {
-                    retval = tree::make<values::ConstBool>(const_bool->value);
-                }
-            }
-            break;
-
-        case TypeEnum::Axis:
-            if (auto const_axis = value->as_const_axis()) {
-                if (!type->assignable) {
-                    retval = tree::make<values::ConstAxis>(const_axis->value);
-                }
-            }
-            break;
-
-        case TypeEnum::Int:
-            if (auto const_int = value->as_const_int()) {
-                if (!type->assignable) {
-                    retval = tree::make<values::ConstInt>(const_int->value);
-                }
-            }
-            break;
-
-        case TypeEnum::Real:
-            if (auto const_int = value->as_const_int()) {
-                if (!type->assignable) {
-                    retval = tree::make<values::ConstReal>(const_int->value);
-                }
-            } else if (auto const_real = value->as_const_real()) {
-                if (!type->assignable) {
-                    retval = tree::make<values::ConstReal>(const_real->value);
-                }
-            }
-            break;
-
-        case TypeEnum::Complex:
-            if (auto const_int = value->as_const_int()) {
-                if (!type->assignable) {
-                    retval = tree::make<values::ConstComplex>(const_int->value);
-                }
-            } else if (auto const_real = value->as_const_real()) {
-                if (!type->assignable) {
-                    retval = tree::make<values::ConstComplex>(const_real->value);
-                }
-            } else if (auto const_complex = value->as_const_complex()) {
-                if (!type->assignable) {
-                    retval = tree::make<values::ConstComplex>(const_complex->value);
-                }
-            }
-            break;
-
-        case TypeEnum::RealMatrix: {
-            auto mat_type = type->as_real_matrix();
-            if (auto const_real_matrix = value->as_const_real_matrix()) {
-                if (!type->assignable) {
-                    // Match matrix size. Negative sizes in the type mean unconstrained.
-                    if ((tree::signed_size_t) const_real_matrix->value.size_rows() == mat_type->num_rows || mat_type->num_rows < 0) {
-                        if ((tree::signed_size_t) const_real_matrix->value.size_cols() == mat_type->num_cols || mat_type->num_cols < 0) {
-                            retval = tree::make<values::ConstRealMatrix>(const_real_matrix->value);
-                        }
-                    }
-                }
-            }
-            break;
-        }
-
-        case TypeEnum::ComplexMatrix: {
-            auto mat_type = type->as_complex_matrix();
-            if (auto const_complex_matrix = value->as_const_complex_matrix()) {
-                if (!type->assignable) {
-                    // Match matrix size. Negative sizes in the type mean unconstrained.
-                    if ((tree::signed_size_t) const_complex_matrix->value.size_rows() == mat_type->num_rows || mat_type->num_rows < 0) {
-                        if ((tree::signed_size_t) const_complex_matrix->value.size_cols() == mat_type->num_cols || mat_type->num_cols < 0) {
-                            retval = tree::make<values::ConstComplexMatrix>(const_complex_matrix->value);
-                        }
-                    }
-                }
-            } else if (auto const_real_matrix = value->as_const_real_matrix()) {
-                if (!type->assignable) {
-                    // Match matrix size. Negative sizes in the type mean unconstrained.
-                    if ((tree::signed_size_t) const_real_matrix->value.size_rows() == mat_type->num_rows || mat_type->num_rows < 0) {
-                        if ((tree::signed_size_t) const_real_matrix->value.size_cols() == mat_type->num_cols || mat_type->num_cols < 0) {
-                            // Convert double to complex.
-                            const size_t rows = const_real_matrix->value.size_rows();
-                            const size_t cols = const_real_matrix->value.size_cols();
-                            cqasm::primitives::CMatrix complex_mat_value(rows, cols);
-                            for (size_t row = 1; row <= rows; row++) {
-                                for (size_t col = 1; col <= cols; col++) {
-                                    complex_mat_value.at(row, col) = const_real_matrix->value.at(row, col);
-                                }
-                            }
-                            retval = tree::make<values::ConstComplexMatrix>(complex_mat_value);
-                            break;
-                        }
-                    }
-                    // NOTE: DEPRECATED BEHAVIOR, FOR BACKWARDS COMPATIBILITY ONLY
-                    // If the expected matrix has a defined size and is square, and
-                    // the real matrix is a vector with the 2 * 4**n entries, we
-                    // interpret it as an old-style cqasm unitary matrix, from
-                    // before cqasm knew what complex numbers (or multidimensional
-                    // matrices) were.
-                    if (mat_type->num_rows == mat_type->num_cols &&
-                        mat_type->num_rows > 0) {
-                        const size_t size = mat_type->num_rows;
-                        const size_t num_elements = 2 * size * size;
-                        if (const_real_matrix->value.size_rows() == 1 && const_real_matrix->value.size_cols() == num_elements) {
-                            cqasm::primitives::CMatrix complex_mat_value(size, size);
-                            size_t index = 1;
-                            for (size_t row = 1; row <= size; row++) {
-                                for (size_t col = 1; col <= size; col++) {
-                                    double re = const_real_matrix->value.at(1, index++);
-                                    double im = const_real_matrix->value.at(1, index++);
-                                    complex_mat_value.at(row, col) = std::complex<double>(re, im);
-                                }
-                            }
-                            retval = tree::make<values::ConstComplexMatrix>(complex_mat_value);
-                        }
-                    }
-                }
-            }
-            break;
-        }
-
-        case TypeEnum::String:
-            if (auto const_string = value->as_const_string()) {
-                if (!type->assignable) {
-                    retval = tree::make<values::ConstString>(const_string->value);
-                }
-            }
-            break;
-
-        case TypeEnum::Json:
-            if (auto const_json = value->as_const_json()) {
-                if (!type->assignable) {
-                    retval = tree::make<values::ConstJson>(const_json->value);
-                }
-            }
-            break;
+    // If the types match exactly, just return the original value.
+    if (types::type_check(type, type_of(value))) {
+        return value;
     }
 
-    // Copy source location annotations into the new object.
+    // Handle promotion rules. If a promotion succeeds, the promoted value is
+    // put in retval.
+    Value retval{};
+
+    // Integers promote to real.
+    if (type->as_real()) {
+        if (auto const_int = value->as_const_int()) {
+            retval = tree::make<values::ConstReal>(const_int->value);
+        }
+    }
+
+    // Integers and reals promote to complex.
+    if (type->as_complex()) {
+        if (auto const_int = value->as_const_int()) {
+            retval = tree::make<values::ConstComplex>(const_int->value);
+        } else if (auto const_real = value->as_const_real()) {
+            retval = tree::make<values::ConstComplex>(const_real->value);
+        }
+    }
+
+    // Real matrix promotes to complex matrix.
+    if (auto mat_type = type->as_complex_matrix()) {
+        if (auto const_real_matrix = value->as_const_real_matrix()) {
+            // Match matrix size. Negative sizes in the type mean unconstrained.
+            if ((tree::signed_size_t) const_real_matrix->value.size_rows() == mat_type->num_rows || mat_type->num_rows < 0) {
+                if ((tree::signed_size_t) const_real_matrix->value.size_cols() == mat_type->num_cols || mat_type->num_cols < 0) {
+                    // Convert double to complex.
+                    const size_t rows = const_real_matrix->value.size_rows();
+                    const size_t cols = const_real_matrix->value.size_cols();
+                    cqasm::primitives::CMatrix complex_mat_value(rows, cols);
+                    for (size_t row = 1; row <= rows; row++) {
+                        for (size_t col = 1; col <= cols; col++) {
+                            complex_mat_value.at(row, col) = const_real_matrix->value.at(row, col);
+                        }
+                    }
+                    retval = tree::make<values::ConstComplexMatrix>(complex_mat_value);
+                }
+            }
+
+            // NOTE: DEPRECATED BEHAVIOR, FOR BACKWARDS COMPATIBILITY ONLY
+            // If the expected matrix has a defined size and is square, and
+            // the real matrix is a vector with the 2 * 4**n entries, we
+            // interpret it as an old-style cqasm unitary matrix, from
+            // before cqasm knew what complex numbers (or multidimensional
+            // matrices) were.
+            if (retval.empty() && mat_type->num_rows == mat_type->num_cols && mat_type->num_rows > 0) {
+                const size_t size = mat_type->num_rows;
+                const size_t num_elements = 2 * size * size;
+                if (const_real_matrix->value.size_rows() == 1 && const_real_matrix->value.size_cols() == num_elements) {
+                    cqasm::primitives::CMatrix complex_mat_value(size, size);
+                    size_t index = 1;
+                    for (size_t row = 1; row <= size; row++) {
+                        for (size_t col = 1; col <= size; col++) {
+                            double re = const_real_matrix->value.at(1, index++);
+                            double im = const_real_matrix->value.at(1, index++);
+                            complex_mat_value.at(row, col) = std::complex<double>(re, im);
+                        }
+                    }
+                    retval = tree::make<values::ConstComplexMatrix>(complex_mat_value);
+                }
+            }
+        }
+    }
+
+    // If a promotion rule was successful, copy the source location annotation
+    // from the old value to the new one.
     if (!retval.empty()) {
         retval->copy_annotation<parser::SourceLocation>(*value);
     }
@@ -210,6 +132,8 @@ types::Type type_of(const Value &value) {
         return tree::make<types::Qubit>(true);
     } else if (value->as_bit_refs()) {
         return tree::make<types::Bool>(true);
+    } else if (auto fn = value->as_function()) {
+        return fn->return_type;
     } else {
         throw std::runtime_error("unknown type!");
     }

--- a/src/cqasm/src/cqasm-values.tree
+++ b/src/cqasm/src/cqasm-values.tree
@@ -12,6 +12,7 @@ tree_namespace cqasm::tree
 
 // Include primitive types.
 include "cqasm-primitives.hpp"
+include "cqasm-types.hpp"
 
 // Initialization function to use to construct default values for the tree base
 // classes and primitives.
@@ -103,7 +104,7 @@ constant {
 
 }
 
-# Represents a reference to a value only known at runtime.
+# Represents a reference to some storage location.
 reference {
 
     # Represents a qubit, or a set of qubits for single-gate-multiple-qubit
@@ -124,5 +125,21 @@ reference {
         index: Many<const_int>;
 
     }
+
+}
+
+# This can be returned by user-defined functions as a placeholder value for
+# something that needs to be evaluated at runtime rather than during constant
+# propagation. Annotations should be used to attach semantic information.
+function {
+
+    # Name of the function as it appears or should appear in the cQASM file.
+    name: cqasm::primitives::Str;
+
+    # Operands for the function.
+    operands: external Any<cqasm::values::Node>;
+
+    # Operands for the function.
+    return_type: external One<cqasm::types::Node>;
 
 }

--- a/src/cqasm/tests/parsing.cpp
+++ b/src/cqasm/tests/parsing.cpp
@@ -126,6 +126,28 @@ public:
         analyzer.register_instruction("reset-averaging", "Q", false, false);
         analyzer.register_instruction("load_state", "s", false, false);
 
+        // Add a dynamic function in order to test the behavior of dynamic
+        // function nodes.
+        analyzer.register_function("or", "bb", [](const cqasm::values::Values &v) -> cqasm::values::Value {
+            auto lhs = v[0];
+            auto rhs = v[1];
+            if (auto lhs_const = lhs->as_const_bool()) {
+                if (lhs_const->value) {
+                    return cqasm::tree::make<cqasm::values::ConstBool>(true);
+                } else {
+                    return rhs;
+                }
+            }
+            if (auto rhs_const = lhs->as_const_bool()) {
+                if (rhs_const->value) {
+                    return cqasm::tree::make<cqasm::values::ConstBool>(true);
+                } else {
+                    return lhs;
+                }
+            }
+            return cqasm::tree::make<cqasm::values::Function>("operator||", v, cqasm::tree::make<cqasm::types::Bool>());
+        });
+
         // Run the actual semantic analysis.
         auto analysis_result = analyzer.analyze(*parse_result.root->as_program());
 

--- a/src/cqasm/tests/parsing/semantic/dyn-func-ok/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/dyn-func-ok/ast.golden.txt
@@ -1,0 +1,395 @@
+SUCCESS
+Program( # input.cq:1:1..8:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: <
+    IntegerLiteral( # input.cq:2:8..10
+      value: 10
+    )
+  >
+  statements: <
+    StatementList( # input.cq:4:1..7:35
+      items: [
+        Bundle( # input.cq:4:1..25
+          items: [
+            Instruction( # input.cq:4:1..25
+              name: <
+                Identifier( # input.cq:4:3..4
+                  name: x
+                )
+              >
+              condition: <
+                FunctionCall( # input.cq:4:5..19
+                  name: <
+                    Identifier( # input.cq:4:5..7
+                      name: or
+                    )
+                  >
+                  arguments: <
+                    ExpressionList( # input.cq:4:8..18
+                      items: [
+                        Identifier( # input.cq:4:8..12
+                          name: true
+                        )
+                        Index( # input.cq:4:14..18
+                          expr: <
+                            Identifier( # input.cq:4:14..15
+                              name: b
+                            )
+                          >
+                          indices: <
+                            IndexList( # input.cq:4:16..17
+                              items: [
+                                IndexItem( # input.cq:4:16..17
+                                  index: <
+                                    IntegerLiteral( # input.cq:4:16..17
+                                      value: 0
+                                    )
+                                  >
+                                )
+                              ]
+                            )
+                          >
+                        )
+                      ]
+                    )
+                  >
+                )
+              >
+              operands: <
+                ExpressionList( # input.cq:4:21..25
+                  items: [
+                    Index( # input.cq:4:21..25
+                      expr: <
+                        Identifier( # input.cq:4:21..22
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:4:23..24
+                          items: [
+                            IndexItem( # input.cq:4:23..24
+                              index: <
+                                IntegerLiteral( # input.cq:4:23..24
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:5:1..26
+          items: [
+            Instruction( # input.cq:5:1..26
+              name: <
+                Identifier( # input.cq:5:3..4
+                  name: x
+                )
+              >
+              condition: <
+                FunctionCall( # input.cq:5:5..20
+                  name: <
+                    Identifier( # input.cq:5:5..7
+                      name: or
+                    )
+                  >
+                  arguments: <
+                    ExpressionList( # input.cq:5:8..19
+                      items: [
+                        Identifier( # input.cq:5:8..13
+                          name: false
+                        )
+                        Index( # input.cq:5:15..19
+                          expr: <
+                            Identifier( # input.cq:5:15..16
+                              name: b
+                            )
+                          >
+                          indices: <
+                            IndexList( # input.cq:5:17..18
+                              items: [
+                                IndexItem( # input.cq:5:17..18
+                                  index: <
+                                    IntegerLiteral( # input.cq:5:17..18
+                                      value: 0
+                                    )
+                                  >
+                                )
+                              ]
+                            )
+                          >
+                        )
+                      ]
+                    )
+                  >
+                )
+              >
+              operands: <
+                ExpressionList( # input.cq:5:22..26
+                  items: [
+                    Index( # input.cq:5:22..26
+                      expr: <
+                        Identifier( # input.cq:5:22..23
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:5:24..25
+                          items: [
+                            IndexItem( # input.cq:5:24..25
+                              index: <
+                                IntegerLiteral( # input.cq:5:24..25
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:6:1..25
+          items: [
+            Instruction( # input.cq:6:1..25
+              name: <
+                Identifier( # input.cq:6:3..4
+                  name: x
+                )
+              >
+              condition: <
+                FunctionCall( # input.cq:6:5..19
+                  name: <
+                    Identifier( # input.cq:6:5..7
+                      name: or
+                    )
+                  >
+                  arguments: <
+                    ExpressionList( # input.cq:6:8..18
+                      items: [
+                        Index( # input.cq:6:8..12
+                          expr: <
+                            Identifier( # input.cq:6:8..9
+                              name: b
+                            )
+                          >
+                          indices: <
+                            IndexList( # input.cq:6:10..11
+                              items: [
+                                IndexItem( # input.cq:6:10..11
+                                  index: <
+                                    IntegerLiteral( # input.cq:6:10..11
+                                      value: 1
+                                    )
+                                  >
+                                )
+                              ]
+                            )
+                          >
+                        )
+                        Index( # input.cq:6:14..18
+                          expr: <
+                            Identifier( # input.cq:6:14..15
+                              name: b
+                            )
+                          >
+                          indices: <
+                            IndexList( # input.cq:6:16..17
+                              items: [
+                                IndexItem( # input.cq:6:16..17
+                                  index: <
+                                    IntegerLiteral( # input.cq:6:16..17
+                                      value: 0
+                                    )
+                                  >
+                                )
+                              ]
+                            )
+                          >
+                        )
+                      ]
+                    )
+                  >
+                )
+              >
+              operands: <
+                ExpressionList( # input.cq:6:21..25
+                  items: [
+                    Index( # input.cq:6:21..25
+                      expr: <
+                        Identifier( # input.cq:6:21..22
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:6:23..24
+                          items: [
+                            IndexItem( # input.cq:6:23..24
+                              index: <
+                                IntegerLiteral( # input.cq:6:23..24
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:7:1..35
+          items: [
+            Instruction( # input.cq:7:1..35
+              name: <
+                Identifier( # input.cq:7:3..4
+                  name: x
+                )
+              >
+              condition: <
+                FunctionCall( # input.cq:7:5..29
+                  name: <
+                    Identifier( # input.cq:7:5..7
+                      name: or
+                    )
+                  >
+                  arguments: <
+                    ExpressionList( # input.cq:7:8..28
+                      items: [
+                        FunctionCall( # input.cq:7:8..22
+                          name: <
+                            Identifier( # input.cq:7:8..10
+                              name: or
+                            )
+                          >
+                          arguments: <
+                            ExpressionList( # input.cq:7:11..21
+                              items: [
+                                Index( # input.cq:7:11..15
+                                  expr: <
+                                    Identifier( # input.cq:7:11..12
+                                      name: b
+                                    )
+                                  >
+                                  indices: <
+                                    IndexList( # input.cq:7:13..14
+                                      items: [
+                                        IndexItem( # input.cq:7:13..14
+                                          index: <
+                                            IntegerLiteral( # input.cq:7:13..14
+                                              value: 2
+                                            )
+                                          >
+                                        )
+                                      ]
+                                    )
+                                  >
+                                )
+                                Index( # input.cq:7:17..21
+                                  expr: <
+                                    Identifier( # input.cq:7:17..18
+                                      name: b
+                                    )
+                                  >
+                                  indices: <
+                                    IndexList( # input.cq:7:19..20
+                                      items: [
+                                        IndexItem( # input.cq:7:19..20
+                                          index: <
+                                            IntegerLiteral( # input.cq:7:19..20
+                                              value: 1
+                                            )
+                                          >
+                                        )
+                                      ]
+                                    )
+                                  >
+                                )
+                              ]
+                            )
+                          >
+                        )
+                        Index( # input.cq:7:24..28
+                          expr: <
+                            Identifier( # input.cq:7:24..25
+                              name: b
+                            )
+                          >
+                          indices: <
+                            IndexList( # input.cq:7:26..27
+                              items: [
+                                IndexItem( # input.cq:7:26..27
+                                  index: <
+                                    IntegerLiteral( # input.cq:7:26..27
+                                      value: 0
+                                    )
+                                  >
+                                )
+                              ]
+                            )
+                          >
+                        )
+                      ]
+                    )
+                  >
+                )
+              >
+              operands: <
+                ExpressionList( # input.cq:7:31..35
+                  items: [
+                    Index( # input.cq:7:31..35
+                      expr: <
+                        Identifier( # input.cq:7:31..32
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:7:33..34
+                          items: [
+                            IndexItem( # input.cq:7:33..34
+                              index: <
+                                IntegerLiteral( # input.cq:7:33..34
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/src/cqasm/tests/parsing/semantic/dyn-func-ok/input.cq
+++ b/src/cqasm/tests/parsing/semantic/dyn-func-ok/input.cq
@@ -1,0 +1,7 @@
+version 1.0
+qubits 10
+
+c-x or(true, b[0]), q[0]
+c-x or(false, b[0]), q[0]
+c-x or(b[1], b[0]), q[0]
+c-x or(or(b[2], b[1]), b[0]), q[0]

--- a/src/cqasm/tests/parsing/semantic/dyn-func-ok/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/dyn-func-ok/semantic.golden.txt
@@ -1,0 +1,180 @@
+SUCCESS
+Program( # input.cq:1:1..8:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: 10
+  error_model: -
+  subcircuits: [
+    Subcircuit( # input.cq:4:1..25
+      name: 
+      iterations: 1
+      bundles: [
+        Bundle( # input.cq:4:1..25
+          items: [
+            Instruction( # input.cq:4:1..25
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                ConstBool( # input.cq:4:5..19
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:4:21..25
+                  index: [
+                    ConstInt( # input.cq:4:23..24
+                      value: 0
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:5:1..26
+          items: [
+            Instruction( # input.cq:5:1..26
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                BitRefs( # input.cq:5:5..20
+                  index: [
+                    ConstInt( # input.cq:5:17..18
+                      value: 0
+                    )
+                  ]
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:5:22..26
+                  index: [
+                    ConstInt( # input.cq:5:24..25
+                      value: 0
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:6:1..25
+          items: [
+            Instruction( # input.cq:6:1..25
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                Function( # input.cq:6:5..19
+                  name: operator||
+                  operands: [
+                    BitRefs( # input.cq:6:8..12
+                      index: [
+                        ConstInt( # input.cq:6:10..11
+                          value: 1
+                        )
+                      ]
+                    )
+                    BitRefs( # input.cq:6:14..18
+                      index: [
+                        ConstInt( # input.cq:6:16..17
+                          value: 0
+                        )
+                      ]
+                    )
+                  ]
+                  return_type: <
+                    Bool(
+                      assignable: 0
+                    )
+                  >
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:6:21..25
+                  index: [
+                    ConstInt( # input.cq:6:23..24
+                      value: 0
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:7:1..35
+          items: [
+            Instruction( # input.cq:7:1..35
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                Function( # input.cq:7:5..29
+                  name: operator||
+                  operands: [
+                    Function( # input.cq:7:8..22
+                      name: operator||
+                      operands: [
+                        BitRefs( # input.cq:7:11..15
+                          index: [
+                            ConstInt( # input.cq:7:13..14
+                              value: 2
+                            )
+                          ]
+                        )
+                        BitRefs( # input.cq:7:17..21
+                          index: [
+                            ConstInt( # input.cq:7:19..20
+                              value: 1
+                            )
+                          ]
+                        )
+                      ]
+                      return_type: <
+                        Bool(
+                          assignable: 0
+                        )
+                      >
+                    )
+                    BitRefs( # input.cq:7:24..28
+                      index: [
+                        ConstInt( # input.cq:7:26..27
+                          value: 0
+                        )
+                      ]
+                    )
+                  ]
+                  return_type: <
+                    Bool(
+                      assignable: 0
+                    )
+                  >
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:7:31..35
+                  index: [
+                    ConstInt( # input.cq:7:33..34
+                      value: 0
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+      annotations: []
+    )
+  ]
+  mappings: []
+)
+


### PR DESCRIPTION
This PR tracks the progress of adding support for "dynamic expressions", i.e. expressions that are evaluated at runtime rather than during semantic evaluation. For example, a construct like `cond (or(b[0], b[1])) x q[0]` would be possible. These are needed to model the conditional execution logic supported by the Central Controller. Classical resources a.k.a. variables, assignment statements, and additional operators will be added later to make usage of this system more ergonomic.