### PR TITLE
Add support for variables

### DIFF
--- a/src/cqasm/include/cqasm-semantic-helper.hpp
+++ b/src/cqasm/include/cqasm-semantic-helper.hpp
@@ -1,0 +1,21 @@
+/** \file
+ * Forward reference for tree::semantic::Variable, so the values tree can use
+ * it (resolves circular dependency).
+ */
+
+#pragma once
+
+namespace cqasm {
+namespace semantic {
+
+// NOTE JvS: This forward declaration is needed in order to allow the value tree
+// to link to Variable nodes in the semantic tree. It's possible to get rid of
+// this kludge by merging the value (and type) trees into the semantic tree, as
+// probably should have been done initially, but a lot of refactoring would
+// result. Instead I'll just keep it in mind when designing cQASM 2.0; the
+// current plan is that it would have its own codebase anyway, and refer back
+// to this one based on the version header if need be.
+class Variable;
+
+}
+}

--- a/src/cqasm/include/cqasm-semantic.hpp
+++ b/src/cqasm/include/cqasm-semantic.hpp
@@ -8,4 +8,5 @@
 
 #pragma once
 
+#include "cqasm-semantic-helper.hpp"
 #include "cqasm-semantic-gen.hpp"

--- a/src/cqasm/src/cqasm-ast.tree
+++ b/src/cqasm/src/cqasm-ast.tree
@@ -247,6 +247,17 @@ annotated {
 
         }
 
+        # One or more variable declaration for some type.
+        variables {
+
+            # Name of the variables. Multiple can be declared on one line.
+            names: Many<identifier>;
+
+            # Name of the type.
+            typ: One<identifier>;
+
+        }
+
         # A subcircuit header.
         subcircuit {
 
@@ -294,7 +305,7 @@ root {
         version: One<version>;
 
         # Integer expression indicating the number of qubits.
-        num_qubits: One<expression>;
+        num_qubits: Maybe<expression>;
 
         # The statement list.
         statements: One<statement_list>;

--- a/src/cqasm/src/cqasm-error-model.cpp
+++ b/src/cqasm/src/cqasm-error-model.cpp
@@ -4,6 +4,7 @@
 
 #include "cqasm-error-model.hpp"
 #include "cqasm-utils.hpp"
+#include "cqasm-semantic.hpp"
 
 namespace cqasm {
 namespace error_model {

--- a/src/cqasm/src/cqasm-instruction.cpp
+++ b/src/cqasm/src/cqasm-instruction.cpp
@@ -4,6 +4,7 @@
 
 #include "cqasm-instruction.hpp"
 #include "cqasm-utils.hpp"
+#include "cqasm-semantic.hpp"
 
 namespace cqasm {
 namespace instruction {

--- a/src/cqasm/src/cqasm-lexer.l
+++ b/src/cqasm/src/cqasm-lexer.l
@@ -107,6 +107,9 @@
     /* Qubit register naming */
 (?i:map)                                            WITHOUT_STR(MAP);
 
+    /* Variable declaration */
+(?i:var)                                            WITHOUT_STR(VAR);
+
     /* C-dash prefix for binary-controlled gates */
 [cC]-/[a-zA-Z_]                                     WITHOUT_STR(CDASH);
 

--- a/src/cqasm/src/cqasm-resolver.cpp
+++ b/src/cqasm/src/cqasm-resolver.cpp
@@ -24,9 +24,16 @@ void MappingTable::add(
     const values::Value &value,
     const tree::Maybe<ast::Mapping> &node
 ) {
+    auto lname = utils::lowercase(name);
+    auto it = table.find(lname);
+    if (it != table.end()) {
+        table.erase(it);
+    }
     table.insert(
-        std::make_pair(utils::lowercase(name),
-        std::pair<const values::Value, tree::Maybe<ast::Mapping>>(value, node))
+        std::make_pair(
+            lname,
+            std::pair<const values::Value, tree::Maybe<ast::Mapping>>(value, node)
+        )
     );
 }
 

--- a/src/cqasm/src/cqasm-semantic.tree
+++ b/src/cqasm/src/cqasm-semantic.tree
@@ -107,7 +107,7 @@ annotated {
 
     }
 
-    # A mappings. That is, a user-defined identifier mapping to some value.
+    # A mapping. That is, a user-defined identifier mapping to some value.
     mapping {
 
         # The name of the mapping.
@@ -115,6 +115,17 @@ annotated {
 
         # The value it maps to.
         value: external One<cqasm::values::Node>;
+
+    }
+
+    # A variable.
+    variable {
+
+        # The name of the variable.
+        name: cqasm::primitives::Str;
+
+        # The type of the variable.
+        typ: external One<cqasm::types::Node>;
 
     }
 
@@ -145,5 +156,8 @@ program {
 
     # The list of all user-defined mappings after parsing.
     mappings: Any<mapping>;
+
+    # This list of all user-defined variables at any point in the code.
+    variables: Any<variable>;
 
 }

--- a/src/cqasm/src/cqasm-types.tree
+++ b/src/cqasm/src/cqasm-types.tree
@@ -12,6 +12,8 @@ tree_namespace cqasm::tree
 
 // Include primitive types.
 include "cqasm-primitives.hpp"
+include "cqasm-semantic-helper.hpp"
+src_include "cqasm-semantic.hpp"
 
 // Initialization function to use to construct default values for the tree base
 // classes and primitives.

--- a/src/cqasm/src/cqasm-values.cpp
+++ b/src/cqasm/src/cqasm-values.cpp
@@ -6,6 +6,7 @@
 #include "cqasm-values.hpp"
 #include "cqasm-types.hpp"
 #include "cqasm-error.hpp"
+#include "cqasm-semantic.hpp"
 
 namespace cqasm {
 namespace values {
@@ -134,6 +135,8 @@ types::Type type_of(const Value &value) {
         return tree::make<types::Bool>(true);
     } else if (auto fn = value->as_function()) {
         return fn->return_type;
+    } else if (auto var = value->as_variable_ref()) {
+        return var->variable->typ;
     } else {
         throw std::runtime_error("unknown type!");
     }

--- a/src/cqasm/src/cqasm-values.tree
+++ b/src/cqasm/src/cqasm-values.tree
@@ -13,6 +13,7 @@ tree_namespace cqasm::tree
 // Include primitive types.
 include "cqasm-primitives.hpp"
 include "cqasm-types.hpp"
+src_include "cqasm-semantic.hpp"
 
 // Initialization function to use to construct default values for the tree base
 // classes and primitives.
@@ -123,6 +124,14 @@ reference {
 
         # The qubit index that this is a measurement bit for, starting at 0.
         index: Many<const_int>;
+
+    }
+
+    # Represents a variable reference.
+    variable_ref {
+
+        # The referenced variable.
+        variable: external Link<cqasm::semantic::Variable>;
 
     }
 

--- a/src/cqasm/tests/parsing/grammar/function/ast.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/function/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..36
+    StatementList( # input.cq:2:1..5:36
       items: [
         Bundle( # input.cq:4:1..36
           items: [

--- a/src/cqasm/tests/parsing/grammar/index-positive/ast.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/index-positive/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..59
+    StatementList( # input.cq:2:1..5:59
       items: [
         Bundle( # input.cq:4:1..59
           items: [

--- a/src/cqasm/tests/parsing/grammar/index-positive/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/index-positive/semantic.golden.txt
@@ -92,5 +92,6 @@ Program( # input.cq:1:1..5:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/grammar/instructions/ast.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/instructions/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..18:1
     )
   >
   statements: <
-    StatementList( # input.cq:5:1..17:60
+    StatementList( # input.cq:2:1..18:60
       items: [
         Bundle( # input.cq:5:1..20
           items: [

--- a/src/cqasm/tests/parsing/grammar/instructions/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/instructions/semantic.golden.txt
@@ -224,5 +224,6 @@ Program( # input.cq:1:1..18:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/grammar/map/ast.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/map/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..6:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..5:50
+    StatementList( # input.cq:2:1..6:50
       items: [
         Mapping( # input.cq:4:1..26
           alias: <

--- a/src/cqasm/tests/parsing/grammar/map/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/map/semantic.golden.txt
@@ -45,5 +45,6 @@ Program( # input.cq:1:1..6:1
       ]
     )
   ]
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/grammar/matrix/ast.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/matrix/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..58
+    StatementList( # input.cq:2:1..5:58
       items: [
         Bundle( # input.cq:4:1..58
           items: [

--- a/src/cqasm/tests/parsing/grammar/matrix/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/matrix/semantic.golden.txt
@@ -55,5 +55,6 @@ Program( # input.cq:1:1..5:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/grammar/operator/ast.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/operator/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..117
+    StatementList( # input.cq:2:1..5:117
       items: [
         Bundle( # input.cq:4:1..117
           items: [

--- a/src/cqasm/tests/parsing/grammar/operator/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/operator/semantic.golden.txt
@@ -49,5 +49,6 @@ Program( # input.cq:1:1..5:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/grammar/subcircuit-default/ast.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/subcircuit-default/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..15:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..14:38
+    StatementList( # input.cq:2:1..15:38
       items: [
         Bundle( # input.cq:4:1..7
           items: [

--- a/src/cqasm/tests/parsing/grammar/subcircuit-default/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/subcircuit-default/semantic.golden.txt
@@ -168,5 +168,6 @@ Program( # input.cq:1:1..15:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/grammar/subcircuit-no-default/ast.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/subcircuit-no-default/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..11:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..10:21
+    StatementList( # input.cq:2:1..11:21
       items: [
         Subcircuit( # input.cq:4:1..19
           name: <

--- a/src/cqasm/tests/parsing/grammar/subcircuit-no-default/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/grammar/subcircuit-no-default/semantic.golden.txt
@@ -71,5 +71,6 @@ Program( # input.cq:1:1..11:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/lexer/comments-positive/ast.golden.txt
+++ b/src/cqasm/tests/parsing/lexer/comments-positive/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..11:1
     )
   >
   statements: <
-    StatementList( # input.cq:5:1..9:40
+    StatementList( # input.cq:2:1..11:40
       items: [
         Bundle( # input.cq:5:1..7:6
           items: [

--- a/src/cqasm/tests/parsing/lexer/comments-positive/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/lexer/comments-positive/semantic.golden.txt
@@ -68,5 +68,6 @@ Program( # input.cq:1:1..11:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/lexer/json-positive/ast.golden.txt
+++ b/src/cqasm/tests/parsing/lexer/json-positive/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..12:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..11:4
+    StatementList( # input.cq:2:1..12:4
       items: [
         Bundle( # input.cq:4:1..11:4
           items: [

--- a/src/cqasm/tests/parsing/lexer/json-positive/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/lexer/json-positive/semantic.golden.txt
@@ -50,5 +50,6 @@ Program( # input.cq:1:1..12:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/lexer/newlines/ast.golden.txt
+++ b/src/cqasm/tests/parsing/lexer/newlines/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..38:1
     )
   >
   statements: <
-    StatementList( # input.cq:5:1..37:33
+    StatementList( # input.cq:2:1..38:33
       items: [
         Bundle( # input.cq:5:1..7
           items: [

--- a/src/cqasm/tests/parsing/lexer/newlines/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/lexer/newlines/semantic.golden.txt
@@ -270,5 +270,6 @@ I'm a multiline string.
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/lexer/numbers-positive/ast.golden.txt
+++ b/src/cqasm/tests/parsing/lexer/numbers-positive/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..68
+    StatementList( # input.cq:2:1..5:68
       items: [
         Bundle( # input.cq:4:1..68
           items: [

--- a/src/cqasm/tests/parsing/lexer/numbers-positive/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/lexer/numbers-positive/semantic.golden.txt
@@ -67,5 +67,6 @@ Program( # input.cq:1:1..5:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/lexer/string-positive/ast.golden.txt
+++ b/src/cqasm/tests/parsing/lexer/string-positive/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..6:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..5:11
+    StatementList( # input.cq:2:1..6:11
       items: [
         Bundle( # input.cq:4:1..5:11
           items: [

--- a/src/cqasm/tests/parsing/lexer/string-positive/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/lexer/string-positive/semantic.golden.txt
@@ -60,5 +60,6 @@ Program( # input.cq:1:1..6:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/misc/grover/ast.golden.txt
+++ b/src/cqasm/tests/parsing/misc/grover/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..56:1
     )
   >
   statements: <
-    StatementList( # input.cq:5:1..53:53
+    StatementList( # input.cq:3:1..56:53
       items: [
         Mapping( # input.cq:5:1..16
           alias: <

--- a/src/cqasm/tests/parsing/misc/grover/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/misc/grover/semantic.golden.txt
@@ -1263,5 +1263,6 @@ Program( # input.cq:1:1..56:1
       annotations: []
     )
   ]
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/misc/minimal/ast.golden.txt
+++ b/src/cqasm/tests/parsing/misc/minimal/ast.golden.txt
@@ -1,17 +1,13 @@
 SUCCESS
-Program( # input.cq:1:1..3:1
+Program( # input.cq:1:1..2:1
   version: <
     Version( # input.cq:1:9..10
       items: 0
     )
   >
-  num_qubits: <
-    IntegerLiteral( # input.cq:2:8..9
-      value: 1
-    )
-  >
+  num_qubits: -
   statements: <
-    StatementList(
+    StatementList( # input.cq:1:10..2:1
       items: []
     )
   >

--- a/src/cqasm/tests/parsing/misc/minimal/input.cq
+++ b/src/cqasm/tests/parsing/misc/minimal/input.cq
@@ -1,2 +1,1 @@
 version 0
-qubits 1

--- a/src/cqasm/tests/parsing/misc/minimal/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/misc/minimal/semantic.golden.txt
@@ -1,13 +1,14 @@
 SUCCESS
-Program( # input.cq:1:1..3:1
+Program( # input.cq:1:1..2:1
   version: <
     Version( # input.cq:1:9..10
       items: 0
     )
   >
-  num_qubits: 1
+  num_qubits: 0
   error_model: -
   subcircuits: []
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/paper/example1/ast.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example1/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..14:1
     )
   >
   statements: <
-    StatementList( # input.cq:6:1..13:15
+    StatementList( # input.cq:3:1..14:15
       items: [
         Bundle( # input.cq:6:1..7
           items: [

--- a/src/cqasm/tests/parsing/paper/example1/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example1/semantic.golden.txt
@@ -120,5 +120,6 @@ Program( # input.cq:1:1..14:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/paper/example2-fixed/ast.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example2-fixed/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..23:1
     )
   >
   statements: <
-    StatementList( # input.cq:6:1..22:24
+    StatementList( # input.cq:3:1..23:24
       items: [
         Mapping( # input.cq:6:1..14
           alias: <

--- a/src/cqasm/tests/parsing/paper/example2-fixed/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example2-fixed/semantic.golden.txt
@@ -256,5 +256,6 @@ Program( # input.cq:1:1..23:1
       annotations: []
     )
   ]
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/paper/example2-original/ast.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example2-original/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..23:1
     )
   >
   statements: <
-    StatementList( # input.cq:6:1..22:24
+    StatementList( # input.cq:3:1..23:24
       items: [
         Mapping( # input.cq:6:1..14
           alias: <

--- a/src/cqasm/tests/parsing/paper/example3-actual-syntax/ast.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example3-actual-syntax/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..18:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..17:18
+    StatementList( # input.cq:2:1..18:18
       items: [
         Bundle( # input.cq:4:1..7
           items: [

--- a/src/cqasm/tests/parsing/paper/example3-actual-syntax/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example3-actual-syntax/semantic.golden.txt
@@ -278,5 +278,6 @@ Program( # input.cq:1:1..18:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/paper/example3-original/ast.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example3-original/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..18:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..17:24
+    StatementList( # input.cq:2:1..18:24
       items: [
         Bundle( # input.cq:4:1..7
           items: [

--- a/src/cqasm/tests/parsing/paper/example4/ast.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example4/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..18:1
     )
   >
   statements: <
-    StatementList( # input.cq:6:1..16:29
+    StatementList( # input.cq:3:1..18:29
       items: [
         Bundle( # input.cq:6:1..7
           items: [

--- a/src/cqasm/tests/parsing/paper/example4/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example4/semantic.golden.txt
@@ -194,5 +194,6 @@ Program( # input.cq:1:1..18:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/paper/example5/ast.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example5/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..11:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..10:47
+    StatementList( # input.cq:2:1..11:47
       items: [
         Bundle( # input.cq:4:1..44
           items: [

--- a/src/cqasm/tests/parsing/paper/example5/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example5/semantic.golden.txt
@@ -297,5 +297,6 @@ Program( # input.cq:1:1..11:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/paper/example6/ast.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example6/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..53:1
     )
   >
   statements: <
-    StatementList( # input.cq:6:1..52:54
+    StatementList( # input.cq:4:1..53:54
       items: [
         Mapping( # input.cq:6:1..16
           alias: <

--- a/src/cqasm/tests/parsing/paper/example6/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example6/semantic.golden.txt
@@ -1263,5 +1263,6 @@ Program( # input.cq:1:1..53:1
       annotations: []
     )
   ]
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/paper/example7-actual-syntax/ast.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example7-actual-syntax/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..35:1
     )
   >
   statements: <
-    StatementList( # input.cq:6:1..31:47
+    StatementList( # input.cq:3:1..35:47
       items: [
         Bundle( # input.cq:6:1..16
           items: [

--- a/src/cqasm/tests/parsing/paper/example7-actual-syntax/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/paper/example7-actual-syntax/semantic.golden.txt
@@ -358,5 +358,6 @@ Program( # input.cq:1:1..35:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/semantic/coercion-fail/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/coercion-fail/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..6:1
     )
   >
   statements: <
-    StatementList( # input.cq:5:1..29
+    StatementList( # input.cq:2:1..6:29
       items: [
         Bundle( # input.cq:5:1..29
           items: [

--- a/src/cqasm/tests/parsing/semantic/coercion-ok/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/coercion-ok/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..12:1
     )
   >
   statements: <
-    StatementList( # input.cq:5:1..11:49
+    StatementList( # input.cq:2:1..12:49
       items: [
         Bundle( # input.cq:5:1..30
           items: [

--- a/src/cqasm/tests/parsing/semantic/coercion-ok/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/coercion-ok/semantic.golden.txt
@@ -98,5 +98,6 @@ Program( # input.cq:1:1..12:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/semantic/constants/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/constants/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..53
+    StatementList( # input.cq:2:1..5:53
       items: [
         Bundle( # input.cq:4:1..53
           items: [

--- a/src/cqasm/tests/parsing/semantic/constants/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/constants/semantic.golden.txt
@@ -64,5 +64,6 @@ Program( # input.cq:1:1..5:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/semantic/dyn-func-ok/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/dyn-func-ok/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..8:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..7:35
+    StatementList( # input.cq:2:1..8:35
       items: [
         Bundle( # input.cq:4:1..25
           items: [

--- a/src/cqasm/tests/parsing/semantic/dyn-func-ok/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/dyn-func-ok/semantic.golden.txt
@@ -176,5 +176,6 @@ Program( # input.cq:1:1..8:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/semantic/error-model-multiple/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/error-model-multiple/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..6:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..5:42
+    StatementList( # input.cq:2:1..6:42
       items: [
         Bundle( # input.cq:4:1..42
           items: [

--- a/src/cqasm/tests/parsing/semantic/error-model-name-missing-1/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/error-model-name-missing-1/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..20
+    StatementList( # input.cq:2:1..5:20
       items: [
         Bundle( # input.cq:4:1..20
           items: [

--- a/src/cqasm/tests/parsing/semantic/error-model-name-missing-2/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/error-model-name-missing-2/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..12
+    StatementList( # input.cq:2:1..5:12
       items: [
         Bundle( # input.cq:4:1..12
           items: [

--- a/src/cqasm/tests/parsing/semantic/error-model-name-unknown/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/error-model-name-unknown/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..20
+    StatementList( # input.cq:2:1..5:20
       items: [
         Bundle( # input.cq:4:1..20
           items: [

--- a/src/cqasm/tests/parsing/semantic/error-model-ok/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/error-model-ok/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..55
+    StatementList( # input.cq:2:1..5:55
       items: [
         Bundle( # input.cq:4:1..55
           items: [

--- a/src/cqasm/tests/parsing/semantic/error-model-ok/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/error-model-ok/semantic.golden.txt
@@ -32,5 +32,6 @@ Program( # input.cq:1:1..5:1
   >
   subcircuits: []
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/semantic/error-model-overload-unknown/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/error-model-overload-unknown/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..41
+    StatementList( # input.cq:2:1..5:41
       items: [
         Bundle( # input.cq:4:1..41
           items: [

--- a/src/cqasm/tests/parsing/semantic/index-not-supported/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/index-not-supported/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..45
+    StatementList( # input.cq:2:1..5:45
       items: [
         Bundle( # input.cq:4:1..45
           items: [

--- a/src/cqasm/tests/parsing/semantic/index-range/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/index-range/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..19:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..18:11
+    StatementList( # input.cq:2:1..19:11
       items: [
         Bundle( # input.cq:4:1..7
           items: [

--- a/src/cqasm/tests/parsing/semantic/insn-condition-const-false/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-const-false/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..16
+    StatementList( # input.cq:2:1..5:16
       items: [
         Bundle( # input.cq:4:1..16
           items: [

--- a/src/cqasm/tests/parsing/semantic/insn-condition-const-false/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-const-false/semantic.golden.txt
@@ -9,5 +9,6 @@ Program( # input.cq:1:1..5:1
   error_model: -
   subcircuits: []
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/semantic/insn-condition-const-true/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-const-true/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..15
+    StatementList( # input.cq:2:1..5:15
       items: [
         Bundle( # input.cq:4:1..15
           items: [

--- a/src/cqasm/tests/parsing/semantic/insn-condition-const-true/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-const-true/semantic.golden.txt
@@ -41,5 +41,6 @@ Program( # input.cq:1:1..5:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/semantic/insn-condition-new-ok/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-new-ok/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..6:1
     )
   >
   statements: <
-    StatementList( # input.cq:5:1..23
+    StatementList( # input.cq:2:1..6:23
       items: [
         Bundle( # input.cq:5:1..23
           items: [

--- a/src/cqasm/tests/parsing/semantic/insn-condition-new-ok/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-new-ok/semantic.golden.txt
@@ -57,5 +57,6 @@ Program( # input.cq:1:1..6:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/semantic/insn-condition-not-bool/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-not-bool/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..13
+    StatementList( # input.cq:2:1..5:13
       items: [
         Bundle( # input.cq:4:1..13
           items: [

--- a/src/cqasm/tests/parsing/semantic/insn-condition-not-supported/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-not-supported/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..21
+    StatementList( # input.cq:2:1..5:21
       items: [
         Bundle( # input.cq:4:1..21
           items: [

--- a/src/cqasm/tests/parsing/semantic/insn-condition-ok/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-ok/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..6:1
     )
   >
   statements: <
-    StatementList( # input.cq:5:1..19
+    StatementList( # input.cq:2:1..6:19
       items: [
         Bundle( # input.cq:5:1..19
           items: [

--- a/src/cqasm/tests/parsing/semantic/insn-condition-ok/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-condition-ok/semantic.golden.txt
@@ -57,5 +57,6 @@ Program( # input.cq:1:1..6:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/semantic/insn-index-size-mismatch/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-index-size-mismatch/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..7:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..6:20
+    StatementList( # input.cq:2:1..7:20
       items: [
         Bundle( # input.cq:4:1..20
           items: [

--- a/src/cqasm/tests/parsing/semantic/insn-name-unknown/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-name-unknown/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..18
+    StatementList( # input.cq:2:1..5:18
       items: [
         Bundle( # input.cq:4:1..18
           items: [

--- a/src/cqasm/tests/parsing/semantic/insn-not-parallelizable/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-not-parallelizable/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..21
+    StatementList( # input.cq:2:1..5:21
       items: [
         Bundle( # input.cq:4:1..21
           items: [

--- a/src/cqasm/tests/parsing/semantic/insn-overload-unknown/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-overload-unknown/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..9
+    StatementList( # input.cq:2:1..5:9
       items: [
         Bundle( # input.cq:4:1..9
           items: [

--- a/src/cqasm/tests/parsing/semantic/insn-qubit-reuse/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/insn-qubit-reuse/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..22:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..21:20
+    StatementList( # input.cq:2:1..22:20
       items: [
         Bundle( # input.cq:4:1..9
           items: [

--- a/src/cqasm/tests/parsing/semantic/matrix-not-rectangular/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/matrix-not-rectangular/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..36
+    StatementList( # input.cq:2:1..5:36
       items: [
         Bundle( # input.cq:4:1..36
           items: [

--- a/src/cqasm/tests/parsing/semantic/matrix-not-supported/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/matrix-not-supported/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..31
+    StatementList( # input.cq:2:1..5:31
       items: [
         Bundle( # input.cq:4:1..31
           items: [

--- a/src/cqasm/tests/parsing/semantic/qubits-negative/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/qubits-negative/ast.golden.txt
@@ -15,7 +15,7 @@ Program( # input.cq:1:1..3:1
     )
   >
   statements: <
-    StatementList(
+    StatementList( # input.cq:2:11..3:1
       items: []
     )
   >

--- a/src/cqasm/tests/parsing/semantic/qubits-not-const-int/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/qubits-not-const-int/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..3:1
     )
   >
   statements: <
-    StatementList(
+    StatementList( # input.cq:2:11..3:1
       items: []
     )
   >

--- a/src/cqasm/tests/parsing/semantic/qubits-variables/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/qubits-variables/ast.golden.txt
@@ -1,0 +1,58 @@
+SUCCESS
+Program( # input.cq:1:1..6:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: -
+  statements: <
+    StatementList( # input.cq:1:1..6:25
+      items: [
+        Variables( # input.cq:3:1..25
+          names: [
+            Identifier( # input.cq:3:11..18
+              name: ancilla
+            )
+            Identifier( # input.cq:3:5..9
+              name: data
+            )
+          ]
+          typ: <
+            Identifier( # input.cq:3:20..25
+              name: qubit
+            )
+          >
+          annotations: []
+        )
+        Bundle( # input.cq:5:1..19
+          items: [
+            Instruction( # input.cq:5:1..19
+              name: <
+                Identifier( # input.cq:5:1..5
+                  name: cnot
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:5:6..19
+                  items: [
+                    Identifier( # input.cq:5:6..10
+                      name: data
+                    )
+                    Identifier( # input.cq:5:12..19
+                      name: ancilla
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/src/cqasm/tests/parsing/semantic/qubits-variables/input.cq
+++ b/src/cqasm/tests/parsing/semantic/qubits-variables/input.cq
@@ -1,0 +1,5 @@
+version 1.0
+
+var data, ancilla: qubit
+
+cnot data, ancilla

--- a/src/cqasm/tests/parsing/semantic/qubits-variables/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/qubits-variables/semantic.golden.txt
@@ -1,0 +1,84 @@
+SUCCESS
+Program( # input.cq:1:1..6:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: 0
+  error_model: -
+  subcircuits: [
+    Subcircuit( # input.cq:5:1..19
+      name: 
+      iterations: 1
+      bundles: [
+        Bundle( # input.cq:5:1..19
+          items: [
+            Instruction( # input.cq:5:1..19
+              instruction: cnot(qubit reference, qubit reference)
+              name: cnot
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                VariableRef( # input.cq:5:6..10
+                  variable --> <
+                    Variable( # input.cq:3:5..9
+                      name: data
+                      typ: <
+                        Qubit(
+                          assignable: 1
+                        )
+                      >
+                      annotations: []
+                    )
+                  >
+                )
+                VariableRef( # input.cq:5:12..19
+                  variable --> <
+                    Variable( # input.cq:3:11..18
+                      name: ancilla
+                      typ: <
+                        Qubit(
+                          assignable: 1
+                        )
+                      >
+                      annotations: []
+                    )
+                  >
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+      annotations: []
+    )
+  ]
+  mappings: []
+  variables: [
+    Variable( # input.cq:3:11..18
+      name: ancilla
+      typ: <
+        Qubit(
+          assignable: 1
+        )
+      >
+      annotations: []
+    )
+    Variable( # input.cq:3:5..9
+      name: data
+      typ: <
+        Qubit(
+          assignable: 1
+        )
+      >
+      annotations: []
+    )
+  ]
+)
+

--- a/src/cqasm/tests/parsing/semantic/qubits-zero/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/qubits-zero/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..3:1
     )
   >
   statements: <
-    StatementList(
+    StatementList( # input.cq:2:9..3:1
       items: []
     )
   >

--- a/src/cqasm/tests/parsing/semantic/subcircuit-iterations-negative/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/subcircuit-iterations-negative/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..14
+    StatementList( # input.cq:2:1..5:14
       items: [
         Subcircuit( # input.cq:4:1..14
           name: <

--- a/src/cqasm/tests/parsing/semantic/subcircuit-iterations-not-const-int/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/subcircuit-iterations-not-const-int/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..14
+    StatementList( # input.cq:2:1..5:14
       items: [
         Subcircuit( # input.cq:4:1..14
           name: <

--- a/src/cqasm/tests/parsing/semantic/subcircuit-iterations-zero/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/subcircuit-iterations-zero/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..5:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..12
+    StatementList( # input.cq:2:1..5:12
       items: [
         Subcircuit( # input.cq:4:1..12
           name: <

--- a/src/cqasm/tests/parsing/semantic/subcircuit-name-reuse/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/subcircuit-name-reuse/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..7:1
     )
   >
   statements: <
-    StatementList( # input.cq:5:1..6:9
+    StatementList( # input.cq:2:1..7:9
       items: [
         Subcircuit( # input.cq:5:1..9
           name: <

--- a/src/cqasm/tests/parsing/semantic/subcircuit-name-reuse/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/subcircuit-name-reuse/semantic.golden.txt
@@ -22,5 +22,6 @@ Program( # input.cq:1:1..7:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/semantic/subcircuit-ok/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/subcircuit-ok/ast.golden.txt
@@ -11,7 +11,7 @@ Program( # input.cq:1:1..13:1
     )
   >
   statements: <
-    StatementList( # input.cq:4:1..12:15
+    StatementList( # input.cq:2:1..13:15
       items: [
         Subcircuit( # input.cq:4:1..11
           name: <

--- a/src/cqasm/tests/parsing/semantic/subcircuit-ok/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/subcircuit-ok/semantic.golden.txt
@@ -127,5 +127,6 @@ Program( # input.cq:1:1..13:1
     )
   ]
   mappings: []
+  variables: []
 )
 

--- a/src/cqasm/tests/parsing/semantic/var-ok/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/var-ok/ast.golden.txt
@@ -1,0 +1,94 @@
+SUCCESS
+Program( # input.cq:1:1..9:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: -
+  statements: <
+    StatementList( # input.cq:1:1..9:15
+      items: [
+        Variables( # input.cq:3:1..13
+          names: [
+            Identifier( # input.cq:3:5..6
+              name: a
+            )
+          ]
+          typ: <
+            Identifier( # input.cq:3:8..13
+              name: qubit
+            )
+          >
+          annotations: []
+        )
+        Variables( # input.cq:4:1..11
+          names: [
+            Identifier( # input.cq:4:5..6
+              name: a
+            )
+          ]
+          typ: <
+            Identifier( # input.cq:4:8..11
+              name: bit
+            )
+          >
+          annotations: []
+        )
+        Variables( # input.cq:5:1..12
+          names: [
+            Identifier( # input.cq:5:5..6
+              name: a
+            )
+          ]
+          typ: <
+            Identifier( # input.cq:5:8..12
+              name: bool
+            )
+          >
+          annotations: []
+        )
+        Variables( # input.cq:6:1..11
+          names: [
+            Identifier( # input.cq:6:5..6
+              name: a
+            )
+          ]
+          typ: <
+            Identifier( # input.cq:6:8..11
+              name: int
+            )
+          >
+          annotations: []
+        )
+        Variables( # input.cq:7:1..12
+          names: [
+            Identifier( # input.cq:7:5..6
+              name: a
+            )
+          ]
+          typ: <
+            Identifier( # input.cq:7:8..12
+              name: real
+            )
+          >
+          annotations: []
+        )
+        Variables( # input.cq:8:1..15
+          names: [
+            Identifier( # input.cq:8:5..6
+              name: a
+            )
+          ]
+          typ: <
+            Identifier( # input.cq:8:8..15
+              name: complex
+            )
+          >
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/src/cqasm/tests/parsing/semantic/var-ok/input.cq
+++ b/src/cqasm/tests/parsing/semantic/var-ok/input.cq
@@ -1,0 +1,8 @@
+version 1.0
+
+var a: qubit
+var a: bit
+var a: bool
+var a: int
+var a: real
+var a: complex

--- a/src/cqasm/tests/parsing/semantic/var-ok/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/var-ok/semantic.golden.txt
@@ -1,0 +1,69 @@
+SUCCESS
+Program( # input.cq:1:1..9:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: 0
+  error_model: -
+  subcircuits: []
+  mappings: []
+  variables: [
+    Variable( # input.cq:3:5..6
+      name: a
+      typ: <
+        Qubit(
+          assignable: 1
+        )
+      >
+      annotations: []
+    )
+    Variable( # input.cq:4:5..6
+      name: a
+      typ: <
+        Bool(
+          assignable: 1
+        )
+      >
+      annotations: []
+    )
+    Variable( # input.cq:5:5..6
+      name: a
+      typ: <
+        Bool(
+          assignable: 1
+        )
+      >
+      annotations: []
+    )
+    Variable( # input.cq:6:5..6
+      name: a
+      typ: <
+        Int(
+          assignable: 1
+        )
+      >
+      annotations: []
+    )
+    Variable( # input.cq:7:5..6
+      name: a
+      typ: <
+        Real(
+          assignable: 1
+        )
+      >
+      annotations: []
+    )
+    Variable( # input.cq:8:5..6
+      name: a
+      typ: <
+        Complex(
+          assignable: 1
+        )
+      >
+      annotations: []
+    )
+  ]
+)
+

--- a/src/cqasm/tests/parsing/semantic/var-shadow/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/var-shadow/ast.golden.txt
@@ -1,0 +1,88 @@
+SUCCESS
+Program( # input.cq:1:1..8:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: -
+  statements: <
+    StatementList( # input.cq:1:1..8:13
+      items: [
+        Variables( # input.cq:3:1..12
+          names: [
+            Identifier( # input.cq:3:5..6
+              name: v
+            )
+          ]
+          typ: <
+            Identifier( # input.cq:3:8..12
+              name: bool
+            )
+          >
+          annotations: []
+        )
+        Bundle( # input.cq:4:1..6
+          items: [
+            Instruction( # input.cq:4:1..6
+              name: <
+                Identifier( # input.cq:4:1..4
+                  name: not
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:4:5..6
+                  items: [
+                    Identifier( # input.cq:4:5..6
+                      name: v
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Variables( # input.cq:6:1..13
+          names: [
+            Identifier( # input.cq:6:5..6
+              name: v
+            )
+          ]
+          typ: <
+            Identifier( # input.cq:6:8..13
+              name: qubit
+            )
+          >
+          annotations: []
+        )
+        Bundle( # input.cq:7:1..4
+          items: [
+            Instruction( # input.cq:7:1..4
+              name: <
+                Identifier( # input.cq:7:1..2
+                  name: x
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:7:3..4
+                  items: [
+                    Identifier( # input.cq:7:3..4
+                      name: v
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/src/cqasm/tests/parsing/semantic/var-shadow/input.cq
+++ b/src/cqasm/tests/parsing/semantic/var-shadow/input.cq
@@ -1,0 +1,7 @@
+version 1.0
+
+var v: bool
+not v
+
+var v: qubit
+x v

--- a/src/cqasm/tests/parsing/semantic/var-shadow/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/var-shadow/semantic.golden.txt
@@ -1,0 +1,101 @@
+SUCCESS
+Program( # input.cq:1:1..8:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: 0
+  error_model: -
+  subcircuits: [
+    Subcircuit( # input.cq:4:1..6
+      name: 
+      iterations: 1
+      bundles: [
+        Bundle( # input.cq:4:1..6
+          items: [
+            Instruction( # input.cq:4:1..6
+              instruction: not(bool/bit reference)
+              name: not
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                VariableRef( # input.cq:4:5..6
+                  variable --> <
+                    Variable( # input.cq:3:5..6
+                      name: v
+                      typ: <
+                        Bool(
+                          assignable: 1
+                        )
+                      >
+                      annotations: []
+                    )
+                  >
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:7:1..4
+          items: [
+            Instruction( # input.cq:7:1..4
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                VariableRef( # input.cq:7:3..4
+                  variable --> <
+                    Variable( # input.cq:6:5..6
+                      name: v
+                      typ: <
+                        Qubit(
+                          assignable: 1
+                        )
+                      >
+                      annotations: []
+                    )
+                  >
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+      annotations: []
+    )
+  ]
+  mappings: []
+  variables: [
+    Variable( # input.cq:3:5..6
+      name: v
+      typ: <
+        Bool(
+          assignable: 1
+        )
+      >
+      annotations: []
+    )
+    Variable( # input.cq:6:5..6
+      name: v
+      typ: <
+        Qubit(
+          assignable: 1
+        )
+      >
+      annotations: []
+    )
+  ]
+)
+

--- a/src/cqasm/tests/parsing/semantic/var-unknown-type/ast.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/var-unknown-type/ast.golden.txt
@@ -1,0 +1,29 @@
+SUCCESS
+Program( # input.cq:1:1..4:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: -
+  statements: <
+    StatementList( # input.cq:1:1..4:18
+      items: [
+        Variables( # input.cq:3:1..18
+          names: [
+            Identifier( # input.cq:3:5..9
+              name: data
+            )
+          ]
+          typ: <
+            Identifier( # input.cq:3:11..18
+              name: unknown
+            )
+          >
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/src/cqasm/tests/parsing/semantic/var-unknown-type/input.cq
+++ b/src/cqasm/tests/parsing/semantic/var-unknown-type/input.cq
@@ -1,0 +1,3 @@
+version 1.0
+
+var data: unknown

--- a/src/cqasm/tests/parsing/semantic/var-unknown-type/semantic.golden.txt
+++ b/src/cqasm/tests/parsing/semantic/var-unknown-type/semantic.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:3:1..18: unknown type "unknown"

--- a/src/library/qasm_new_to_old.hpp
+++ b/src/library/qasm_new_to_old.hpp
@@ -289,8 +289,14 @@ static void handle_parse_result(QasmRepresentation &qasm, cqasm::parser::ParseRe
     //   memory leaks. This is legacy behavior intentionally kept
     //   for backward compatibility.
 
-    // Copy number of qubits.
+    // Handle storage locations.
+    if (analysis_result.root->num_qubits == 0) {
+        throw std::runtime_error("qubits statement is missing");
+    }
     qasm.qubitRegister(analysis_result.root->num_qubits);
+    if (!analysis_result.root->variables.empty()) {
+        throw std::runtime_error("variables are not supported");
+    }
 
     // Copy version number (poorly).
     double version = analysis_result.root->version->items[0];

--- a/src/tests/test_data/invalid.qasm
+++ b/src/tests/test_data/invalid.qasm
@@ -3,7 +3,7 @@
 version 1.0
 qubits 8
 
-map q[0,0:7,5,6], x
+map q[0,0:7,5,6], xx
 map b[5:7], bleh
 
 


### PR DESCRIPTION
This adds additional syntax for specifying conditional gates, as agreed upon within the context of work package 15. The syntax is necessary to model classical state beyond what is currently supported through implicit measurement bits associated with qubits (a model which doesn't fit the central controller backend to begin with). The syntax is:

```
var <comma-separated-names>: <type>
```

where `<type>` is one of `qubit`, `bit`, `bool`, `int`, `real`, or `complex`. `bit` and `bool` are synonyms for the same type. I didn't add user-accessible types for the axis and string-like types that already exist in libqasm because they likely wouldn't be used anyway, and didn't do so for the matrix types because the syntax would be more difficult, and indexation is only partly supported, so they wouldn't be very usable yet anyway.

The `qubits <count>` statement at the top of the code is now optional, as qubit variables serve as an alternative. It's up to the programs/libraries using libqasm to decide which (or both) style they want to support. The old API of course only supports the old style, as it has no way of representing variables. Note that the default `measure` instruction is not applicable for the new style, as it lacks an explicit result variable; it is up to the library/program using libqasm to check whether the program is sane in this regard.

Aside from the new keyword (`var`), this does not break anything.