### PR TITLE
Fix minimum CMake version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
-if(CMAKE_VERSION VERSION_GREATER 3.0)
-    CMAKE_POLICY(SET CMP0048 NEW)
-endif()
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 project(cqasm CXX)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM centos:6
 
 RUN yum install -y centos-release-scl && \
-    yum install -y devtoolset-7 cmake git
+    yum install -y devtoolset-7 git wget
+
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.12.0/cmake-3.12.0-Linux-x86_64.sh
+RUN chmod +x cmake-3.12.0-Linux-x86_64.sh && ./cmake-3.12.0-Linux-x86_64.sh --skip-license
 
 # Add this line to test CMake logic for when an older version of flex/bison is
 # already installed (that is, to make sure it uses the version it built from

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![API docs](https://readthedocs.org/projects/libqasm/badge/?version=latest)](https://libqasm.readthedocs.io/en/latest/)
 
 ## Dependencies
-* Flex (> 2.6)
-* Bison (> 3.0)
-* cmake (> 2.8)
+* Flex (>= 2.6.1)
+* Bison (>= 3.0)
+* cmake (>= 3.12)
 * gcc and g++ capable of C++11 standard
 * MinGW (For Windows builds)
 * doctest (As a git submodule)

--- a/src/cqasm/CMakeLists.txt
+++ b/src/cqasm/CMakeLists.txt
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
-if(CMAKE_VERSION VERSION_GREATER 3.0)
-    CMAKE_POLICY(SET CMP0048 NEW)
-endif()
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 project(libcqasm CXX)
 


### PR DESCRIPTION
I guess various problems slipped in during #112 that upped the minimum CMake version from 2.8.11 all the way to 3.12. This has to do with object libraries linking to other object libraries. The object libraries are needed at all for pre-#105 build-system compatibility (the old build system would produce both a static and shared library for libqasm, which cannot be done with normal libraries), and until 3.12, object libraries did not support transitive dependency resolution.

I'm not sure it's worth spending more on ancient CMake version compatibility than the half a day I wasted on this already, as installing a newer CMake than your package manager supports is pretty easy (CMake provides its own binary builds for all platforms). If someone does have a problem with this at some point please open an issue and state which minimum version I'd have to target.