### PR TITLE
Namespace stream operators

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Install dependencies
       run: |
         brew install bison flex swig
-        echo "::add-path::/usr/local/opt/bison/bin"
-        echo "::add-path::/usr/local/opt/flex/bin"
+        echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
+        echo "/usr/local/opt/flex/bin" >> $GITHUB_PATH
         python -m pip install --upgrade pip setuptools wheel
     - name: Build wheel
       env:

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -184,7 +184,7 @@ jobs:
       with:
         submodules: true
     - name: Set up conda
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
         miniconda-version: "latest"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,6 @@ jobs:
   python:
     name: Python
     runs-on: ${{ matrix.os }}
-    env:
-      LIBQASM_BUILD_TYPE: 'Debug'
     strategy:
       fail-fast: false
       matrix:
@@ -73,13 +71,16 @@ jobs:
       run: python -m pip install --upgrade pip setuptools wheel pytest numpy
     - name: Install dependencies
       if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get install -y swig
+      run: |
+        sudo apt-get install -y swig
+        echo "LIBQASM_BUILD_TYPE=Debug" >> $GITHUB_ENV
     - name: Install dependencies
       if: matrix.os == 'macos-latest'
       run: |
         brew install bison flex swig
         echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
         echo "/usr/local/opt/flex/bin" >> $GITHUB_PATH
+        echo "LIBQASM_BUILD_TYPE=Debug" >> $GITHUB_ENV
     - uses: actions/cache@v2
       if: matrix.os == 'windows-latest'
       with:
@@ -94,7 +95,7 @@ jobs:
       run: |
         choco install winflexbison3 --version 2.5.18.20190508
         choco install swig --version 4.0.1
-        echo "::set-env name=LIBQASM_BUILD_TYPE::Release"
+        echo "LIBQASM_BUILD_TYPE=Release" >> $GITHUB_ENV
     - name: Build
       env:
         NPROCS: 100
@@ -117,7 +118,7 @@ jobs:
       with:
         submodules: true
     - name: Set up conda
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
         miniconda-version: "latest"
@@ -146,7 +147,7 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
-    container: centos:6
+    container: centos:7
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         brew install bison flex
-        echo "::add-path::/usr/local/opt/bison/bin"
-        echo "::add-path::/usr/local/opt/flex/bin"
+        echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
+        echo "/usr/local/opt/flex/bin" >> $GITHUB_PATH
     - uses: actions/cache@v2
       if: matrix.os == 'windows-latest'
       with:
@@ -78,8 +78,8 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         brew install bison flex swig
-        echo "::add-path::/usr/local/opt/bison/bin"
-        echo "::add-path::/usr/local/opt/flex/bin"
+        echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
+        echo "/usr/local/opt/flex/bin" >> $GITHUB_PATH
     - uses: actions/cache@v2
       if: matrix.os == 'windows-latest'
       with:

--- a/src/cqasm/include/cqasm-error-model.hpp
+++ b/src/cqasm/include/cqasm-error-model.hpp
@@ -76,15 +76,15 @@ public:
  */
 using ErrorModelRef = tree::Maybe<ErrorModel>;
 
-} // namespace error_model
-} // namespace cqasm
-
 /**
  * Stream << overload for error models.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::error_model::ErrorModel& model);
+std::ostream &operator<<(std::ostream &os, const ErrorModel &model);
 
 /**
  * Stream << overload for error model references.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::error_model::ErrorModelRef& model);
+std::ostream &operator<<(std::ostream &os, const ErrorModelRef &model);
+
+} // namespace error_model
+} // namespace cqasm

--- a/src/cqasm/include/cqasm-instruction.hpp
+++ b/src/cqasm/include/cqasm-instruction.hpp
@@ -122,15 +122,15 @@ public:
  */
 using InstructionRef = tree::Maybe<Instruction>;
 
-} // namespace instruction
-} // namespace cqasm
-
 /**
  * Stream << overload for instructions.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::instruction::Instruction& insn);
+std::ostream &operator<<(std::ostream &os, const Instruction &insn);
 
 /**
  * Stream << overload for instruction references.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::instruction::InstructionRef& insn);
+std::ostream &operator<<(std::ostream &os, const InstructionRef &insn);
+
+} // namespace instruction
+} // namespace cqasm

--- a/src/cqasm/include/cqasm-parse-helper.hpp
+++ b/src/cqasm/include/cqasm-parse-helper.hpp
@@ -177,10 +177,10 @@ public:
 
 };
 
-} // namespace parser
-} // namespace cqasm
-
 /**
  * Stream << overload for source location objects.
  */
-std::ostream& operator<<(std::ostream& os, const cqasm::parser::SourceLocation& object);
+std::ostream &operator<<(std::ostream &os, const SourceLocation &object);
+
+} // namespace parser
+} // namespace cqasm

--- a/src/cqasm/include/cqasm-primitives.hpp
+++ b/src/cqasm/include/cqasm-primitives.hpp
@@ -210,19 +210,16 @@ public:
 
 };
 
-} // namespace primitives
-} // namespace cqasm
-
 /**
  * Stream << overload for axis nodes.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::primitives::Axis& axis);
+std::ostream &operator<<(std::ostream &os, const Axis &axis);
 
 /**
  * Stream << overload for matrix nodes.
  */
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const ::cqasm::primitives::Matrix<T>& mat) {
+std::ostream &operator<<(std::ostream &os, const Matrix<T> &mat) {
     os << "[";
     for (size_t row = 1; row <= mat.size_rows(); row++) {
         if (row > 1) {
@@ -242,4 +239,7 @@ std::ostream& operator<<(std::ostream& os, const ::cqasm::primitives::Matrix<T>&
 /**
  * Stream << overload for version nodes.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::primitives::Version& object);
+std::ostream &operator<<(std::ostream &os, const Version &object);
+
+} // namespace primitives
+} // namespace cqasm

--- a/src/cqasm/include/cqasm-types.hpp
+++ b/src/cqasm/include/cqasm-types.hpp
@@ -55,15 +55,15 @@ Types from_spec(const std::string &spec);
  */
 bool type_check(const Type &expected, const Type &actual);
 
-} // namespace types
-} // namespace cqasm
-
 /**
  * Stream << overload for a single type.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::types::Type& type);
+std::ostream &operator<<(std::ostream &os, const Type &type);
 
 /**
  * Stream << overload for zero or more types.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::types::Types& types);
+std::ostream &operator<<(std::ostream &os, const Types &types);
+
+} // namespace types
+} // namespace cqasm

--- a/src/cqasm/include/cqasm-values.hpp
+++ b/src/cqasm/include/cqasm-values.hpp
@@ -60,15 +60,15 @@ void check_const(const Value &value);
  */
 void check_const(const Values &values);
 
-} // namespace values
-} // namespace cqasm
-
 /**
  * Stream << overload for a single value.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::values::Value& value);
+std::ostream &operator<<(std::ostream &os, const Value &value);
 
 /**
  * Stream << overload for zero or more values.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::values::Values& values);
+std::ostream &operator<<(std::ostream &os, const Values &values);
+
+} // namespace values
+} // namespace cqasm

--- a/src/cqasm/src/cqasm-error-model.cpp
+++ b/src/cqasm/src/cqasm-error-model.cpp
@@ -25,17 +25,14 @@ ErrorModel::ErrorModel(
 /**
  * Equality operator.
  */
-bool ErrorModel::operator==(const ErrorModel& rhs) const {
+bool ErrorModel::operator==(const ErrorModel &rhs) const {
     return utils::case_insensitive_equals(name, rhs.name) && param_types == rhs.param_types;
 }
-
-} // namespace error_model
-} // namespace cqasm
 
 /**
  * Stream << overload for error models.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::error_model::ErrorModel& model) {
+std::ostream &operator<<(std::ostream &os, const ErrorModel &model) {
     os << model.name << model.param_types;
     return os;
 }
@@ -43,7 +40,7 @@ std::ostream& operator<<(std::ostream& os, const ::cqasm::error_model::ErrorMode
 /**
  * Stream << overload for error model references.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::error_model::ErrorModelRef& model) {
+std::ostream &operator<<(std::ostream &os, const ErrorModelRef &model) {
     if (model.empty()) {
         os << "unresolved";
     } else {
@@ -51,3 +48,6 @@ std::ostream& operator<<(std::ostream& os, const ::cqasm::error_model::ErrorMode
     }
     return os;
 }
+
+} // namespace error_model
+} // namespace cqasm

--- a/src/cqasm/src/cqasm-instruction.cpp
+++ b/src/cqasm/src/cqasm-instruction.cpp
@@ -49,13 +49,10 @@ bool Instruction::operator==(const Instruction& rhs) const {
             && allow_reused_qubits == rhs.allow_reused_qubits;
 }
 
-} // namespace instruction
-} // namespace cqasm
-
 /**
  * Stream << overload for instructions.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::instruction::Instruction& insn) {
+std::ostream &operator<<(std::ostream &os, const Instruction &insn) {
     os << insn.name << insn.param_types;
     return os;
 }
@@ -63,7 +60,7 @@ std::ostream& operator<<(std::ostream& os, const ::cqasm::instruction::Instructi
 /**
  * Stream << overload for instruction references.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::instruction::InstructionRef& insn) {
+std::ostream &operator<<(std::ostream &os, const InstructionRef &insn) {
     if (insn.empty()) {
         os << "unresolved";
     } else {
@@ -71,3 +68,6 @@ std::ostream& operator<<(std::ostream& os, const ::cqasm::instruction::Instructi
     }
     return os;
 }
+
+} // namespace instruction
+} // namespace cqasm

--- a/src/cqasm/src/cqasm-parse-helper.cpp
+++ b/src/cqasm/src/cqasm-parse-helper.cpp
@@ -188,13 +188,10 @@ void SourceLocation::expand_to_include(uint32_t line, uint32_t column) {
     }
 }
 
-} // namespace parser
-} // namespace cqasm
-
 /**
  * Stream << overload for source location objects.
  */
-std::ostream& operator<<(std::ostream& os, const cqasm::parser::SourceLocation& object) {
+std::ostream &operator<<(std::ostream &os, const SourceLocation &object) {
 
     // Print filename.
     os << object.filename;
@@ -237,3 +234,6 @@ std::ostream& operator<<(std::ostream& os, const cqasm::parser::SourceLocation& 
 
     return os;
 }
+
+} // namespace parser
+} // namespace cqasm

--- a/src/cqasm/src/cqasm-primitives.cpp
+++ b/src/cqasm/src/cqasm-primitives.cpp
@@ -67,13 +67,10 @@ int Version::compare(const std::string &other) const {
     return compare(Version(other));
 }
 
-} // namespace primitives
-} // namespace cqasm
-
 /**
  * Stream << overload for axis nodes.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::primitives::Axis& axis) {
+std::ostream &operator<<(std::ostream &os, const Axis &axis) {
     switch (axis) {
         case ::cqasm::primitives::Axis::X:
             os << "X";
@@ -91,7 +88,7 @@ std::ostream& operator<<(std::ostream& os, const ::cqasm::primitives::Axis& axis
 /**
  * Stream << overload for version nodes.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::primitives::Version& object) {
+std::ostream &operator<<(std::ostream &os, const Version &object) {
     bool first = true;
     for (auto item : object) {
         if (first) {
@@ -103,3 +100,6 @@ std::ostream& operator<<(std::ostream& os, const ::cqasm::primitives::Version& o
     }
     return os;
 }
+
+} // namespace primitives
+} // namespace cqasm

--- a/src/cqasm/src/cqasm-types.cpp
+++ b/src/cqasm/src/cqasm-types.cpp
@@ -136,10 +136,7 @@ bool type_check(const Type &expected, const Type &actual) {
     return true;
 }
 
-} // namespace types
-} // namespace cqasm
-
-static void mat_size(std::ostream& os, tree::signed_size_t nrows, tree::signed_size_t ncols) {
+static void mat_size(std::ostream &os, tree::signed_size_t nrows, tree::signed_size_t ncols) {
     if (ncols == 0) {
         os << "empty matrix";
     } else if (nrows == 1) {
@@ -163,7 +160,7 @@ static void mat_size(std::ostream& os, tree::signed_size_t nrows, tree::signed_s
 /**
  * Stream << overload for a single type.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::types::Type& type) {
+std::ostream &operator<<(std::ostream &os, const Type &type) {
     if (type.empty()) {
         os << "!EMPTY";
     } else if (type->as_bool()) {
@@ -202,7 +199,7 @@ std::ostream& operator<<(std::ostream& os, const ::cqasm::types::Type& type) {
 /**
  * Stream << overload for zero or more types.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::types::Types& types) {
+std::ostream &operator<<(std::ostream &os, const Types &types) {
     os << "(";
     bool first = true;
     for (const auto &type : types) {
@@ -216,3 +213,6 @@ std::ostream& operator<<(std::ostream& os, const ::cqasm::types::Types& types) {
     os << ")";
     return os;
 }
+
+} // namespace types
+} // namespace cqasm

--- a/src/cqasm/src/cqasm-values.cpp
+++ b/src/cqasm/src/cqasm-values.cpp
@@ -173,14 +173,10 @@ void check_const(const Values &values) {
     }
 }
 
-
-} // namespace values
-} // namespace cqasm
-
 /**
  * Stream << overload for a single value.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::values::Value& value) {
+std::ostream &operator<<(std::ostream &os, const Value &value) {
     if (value.empty()) {
         os << "NULL";
     } else {
@@ -192,7 +188,7 @@ std::ostream& operator<<(std::ostream& os, const ::cqasm::values::Value& value) 
 /**
  * Stream << overload for zero or more values.
  */
-std::ostream& operator<<(std::ostream& os, const ::cqasm::values::Values& values) {
+std::ostream &operator<<(std::ostream &os, const Values &values) {
     os << "[";
     bool first = true;
     for (const auto &value : values) {
@@ -210,3 +206,6 @@ std::ostream& operator<<(std::ostream& os, const ::cqasm::values::Values& values
     os << "]";
     return os;
 }
+
+} // namespace values
+} // namespace cqasm


### PR DESCRIPTION
Apparently, operators operating on things from different namespaces don't have to be declared in the global namespace due to dark magic and reasons, and in fact C++ prevents you from using them in that case in some circumstances. Also fixes some missing end-of.namespace comments.

Also updates deprecated ::add-path command in github workflows.