### PR TITLE
Added tests for barriers instruction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ library/**/*_swig*
 
 .idea/
 cmake-build-*/
+
+tags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(
     OFF
 )
 if (LIBQASM_BUILD_TESTS)
+    set(CMAKE_CTEST_ARGUMENTS "--output-on-failure")
     enable_testing()
 endif()
 

--- a/src/cqasm/src/cqasm-v1.cpp
+++ b/src/cqasm/src/cqasm-v1.cpp
@@ -109,6 +109,7 @@ analyzer::Analyzer default_analyzer(const std::string &api_version) {
     analyzer.register_instruction("display_binary", "B", false, false);
     analyzer.register_instruction("skip", "i", false, false);
     analyzer.register_instruction("wait", "i", false, false);
+    analyzer.register_instruction("barrier", "Q", false, false);
     analyzer.register_instruction("reset-averaging", "", false, false);
     analyzer.register_instruction("reset-averaging", "Q", false, false);
     analyzer.register_instruction("load_state", "s", false, false);

--- a/src/cqasm/tests/parsing-tools.py
+++ b/src/cqasm/tests/parsing-tools.py
@@ -11,6 +11,7 @@ if len(sys.argv) != 2:
 
 from plumbum import local, FG
 
+
 def diff():
     is_test_dir = False
     for t in ('ast', 'semantic.1.0', 'semantic.1.1', 'semantic.1.2'):

--- a/src/cqasm/tests/v1-parsing.cpp
+++ b/src/cqasm/tests/v1-parsing.cpp
@@ -133,6 +133,7 @@ public:
             analyzer.register_instruction("display_binary", "B", false, false);
             analyzer.register_instruction("skip", "i", false, false);
             analyzer.register_instruction("wait", "i", false, false);
+            analyzer.register_instruction("barrier", "Q", false, false);
             analyzer.register_instruction("reset-averaging", "", false, false);
             analyzer.register_instruction("reset-averaging", "Q", false, false);
             analyzer.register_instruction("load_state", "s", false, false);

--- a/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-1/ast.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-1/ast.golden.txt
@@ -1,0 +1,248 @@
+SUCCESS
+Program( # input.cq:1:1..9:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: <
+    IntegerLiteral( # input.cq:2:8..9
+      value: 2
+    )
+  >
+  statements: <
+    StatementList( # input.cq:2:1..9:22
+      items: [
+        Bundle( # input.cq:4:1..7
+          items: [
+            Instruction( # input.cq:4:1..7
+              name: <
+                Identifier( # input.cq:4:1..2
+                  name: x
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:4:3..7
+                  items: [
+                    Index( # input.cq:4:3..7
+                      expr: <
+                        Identifier( # input.cq:4:3..4
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:4:5..6
+                          items: [
+                            IndexItem( # input.cq:4:5..6
+                              index: <
+                                IntegerLiteral( # input.cq:4:5..6
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:5:1..15
+          items: [
+            Instruction( # input.cq:5:1..15
+              name: <
+                Identifier( # input.cq:5:1..10
+                  name: measure_z
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:5:11..15
+                  items: [
+                    Index( # input.cq:5:11..15
+                      expr: <
+                        Identifier( # input.cq:5:11..12
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:5:13..14
+                          items: [
+                            IndexItem( # input.cq:5:13..14
+                              index: <
+                                IntegerLiteral( # input.cq:5:13..14
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:6:1..7
+          items: [
+            Instruction( # input.cq:6:1..7
+              name: <
+                Identifier( # input.cq:6:1..2
+                  name: x
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:6:3..7
+                  items: [
+                    Index( # input.cq:6:3..7
+                      expr: <
+                        Identifier( # input.cq:6:3..4
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:6:5..6
+                          items: [
+                            IndexItem( # input.cq:6:5..6
+                              index: <
+                                IntegerLiteral( # input.cq:6:5..6
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:7:1..22
+          items: [
+            Instruction( # input.cq:7:1..22
+              name: <
+                Identifier( # input.cq:7:3..10
+                  name: barrier
+                )
+              >
+              condition: <
+                Index( # input.cq:7:11..15
+                  expr: <
+                    Identifier( # input.cq:7:11..12
+                      name: b
+                    )
+                  >
+                  indices: <
+                    IndexList( # input.cq:7:13..14
+                      items: [
+                        IndexItem( # input.cq:7:13..14
+                          index: <
+                            IntegerLiteral( # input.cq:7:13..14
+                              value: 0
+                            )
+                          >
+                        )
+                      ]
+                    )
+                  >
+                )
+              >
+              operands: <
+                ExpressionList( # input.cq:7:16..22
+                  items: [
+                    Index( # input.cq:7:16..22
+                      expr: <
+                        Identifier( # input.cq:7:16..17
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:7:18..21
+                          items: [
+                            IndexItem( # input.cq:7:18..19
+                              index: <
+                                IntegerLiteral( # input.cq:7:18..19
+                                  value: 0
+                                )
+                              >
+                            )
+                            IndexItem( # input.cq:7:20..21
+                              index: <
+                                IntegerLiteral( # input.cq:7:20..21
+                                  value: 1
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:8:1..7
+          items: [
+            Instruction( # input.cq:8:1..7
+              name: <
+                Identifier( # input.cq:8:1..2
+                  name: x
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:8:3..7
+                  items: [
+                    Index( # input.cq:8:3..7
+                      expr: <
+                        Identifier( # input.cq:8:3..4
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:8:5..6
+                          items: [
+                            IndexItem( # input.cq:8:5..6
+                              index: <
+                                IntegerLiteral( # input.cq:8:5..6
+                                  value: 1
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-1/input.cq
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-1/input.cq
@@ -1,0 +1,8 @@
+version 1.0
+qubits 2
+
+x q[0]
+measure_z q[0]
+x q[0]
+c-barrier b[0],q[0,1]
+x q[1]

--- a/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-1/semantic.1.0.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-1/semantic.1.0.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:7:1..22: conditional execution is not supported for this instruction

--- a/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-1/semantic.1.1.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-1/semantic.1.1.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:7:1..22: conditional execution is not supported for this instruction

--- a/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-1/semantic.1.2.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-1/semantic.1.2.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:7:1..22: conditional execution is not supported for this instruction

--- a/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-2/ast.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-2/ast.golden.txt
@@ -1,0 +1,160 @@
+SUCCESS
+Program( # input.cq:1:1..7:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: <
+    IntegerLiteral( # input.cq:2:8..9
+      value: 2
+    )
+  >
+  statements: <
+    StatementList( # input.cq:2:1..7:19
+      items: [
+        Bundle( # input.cq:4:1..7
+          items: [
+            Instruction( # input.cq:4:1..7
+              name: <
+                Identifier( # input.cq:4:1..2
+                  name: x
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:4:3..7
+                  items: [
+                    Index( # input.cq:4:3..7
+                      expr: <
+                        Identifier( # input.cq:4:3..4
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:4:5..6
+                          items: [
+                            IndexItem( # input.cq:4:5..6
+                              index: <
+                                IntegerLiteral( # input.cq:4:5..6
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:5:1..19
+          items: [
+            Instruction( # input.cq:5:1..19
+              name: <
+                Identifier( # input.cq:5:1..8
+                  name: barrier
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:5:9..19
+                  items: [
+                    Index( # input.cq:5:9..13
+                      expr: <
+                        Identifier( # input.cq:5:9..10
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:5:11..12
+                          items: [
+                            IndexItem( # input.cq:5:11..12
+                              index: <
+                                IntegerLiteral( # input.cq:5:11..12
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                    Index( # input.cq:5:15..19
+                      expr: <
+                        Identifier( # input.cq:5:15..16
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:5:17..18
+                          items: [
+                            IndexItem( # input.cq:5:17..18
+                              index: <
+                                IntegerLiteral( # input.cq:5:17..18
+                                  value: 1
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:6:1..7
+          items: [
+            Instruction( # input.cq:6:1..7
+              name: <
+                Identifier( # input.cq:6:1..2
+                  name: x
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:6:3..7
+                  items: [
+                    Index( # input.cq:6:3..7
+                      expr: <
+                        Identifier( # input.cq:6:3..4
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:6:5..6
+                          items: [
+                            IndexItem( # input.cq:6:5..6
+                              index: <
+                                IntegerLiteral( # input.cq:6:5..6
+                                  value: 1
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-2/input.cq
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-2/input.cq
@@ -1,0 +1,6 @@
+version 1.0
+qubits 2
+
+x q[0]
+barrier q[0], q[1]
+x q[1]

--- a/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-2/semantic.1.0.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-2/semantic.1.0.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:5:1..19: failed to resolve overload for barrier with argument pack (qubit reference, qubit reference)

--- a/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-2/semantic.1.1.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-2/semantic.1.1.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:5:1..19: failed to resolve overload for barrier with argument pack (qubit reference, qubit reference)

--- a/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-2/semantic.1.2.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-not-ok-2/semantic.1.2.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:5:1..19: failed to resolve overload for barrier with argument pack (qubit reference, qubit reference)

--- a/src/cqasm/tests/v1-parsing/misc/barriers-ok-1/ast.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-ok-1/ast.golden.txt
@@ -1,0 +1,272 @@
+SUCCESS
+Program( # input.cq:1:1..10:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: <
+    IntegerLiteral( # input.cq:2:8..9
+      value: 3
+    )
+  >
+  statements: <
+    StatementList( # input.cq:2:1..10:15
+      items: [
+        Bundle( # input.cq:4:1..7
+          items: [
+            Instruction( # input.cq:4:1..7
+              name: <
+                Identifier( # input.cq:4:1..2
+                  name: x
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:4:3..7
+                  items: [
+                    Index( # input.cq:4:3..7
+                      expr: <
+                        Identifier( # input.cq:4:3..4
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:4:5..6
+                          items: [
+                            IndexItem( # input.cq:4:5..6
+                              index: <
+                                IntegerLiteral( # input.cq:4:5..6
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:5:1..15
+          items: [
+            Instruction( # input.cq:5:1..15
+              name: <
+                Identifier( # input.cq:5:1..8
+                  name: barrier
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:5:9..15
+                  items: [
+                    Index( # input.cq:5:9..15
+                      expr: <
+                        Identifier( # input.cq:5:9..10
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:5:11..14
+                          items: [
+                            IndexItem( # input.cq:5:11..12
+                              index: <
+                                IntegerLiteral( # input.cq:5:11..12
+                                  value: 0
+                                )
+                              >
+                            )
+                            IndexItem( # input.cq:5:13..14
+                              index: <
+                                IntegerLiteral( # input.cq:5:13..14
+                                  value: 1
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:6:1..7
+          items: [
+            Instruction( # input.cq:6:1..7
+              name: <
+                Identifier( # input.cq:6:1..2
+                  name: x
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:6:3..7
+                  items: [
+                    Index( # input.cq:6:3..7
+                      expr: <
+                        Identifier( # input.cq:6:3..4
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:6:5..6
+                          items: [
+                            IndexItem( # input.cq:6:5..6
+                              index: <
+                                IntegerLiteral( # input.cq:6:5..6
+                                  value: 1
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:7:1..15
+          items: [
+            Instruction( # input.cq:7:1..15
+              name: <
+                Identifier( # input.cq:7:1..8
+                  name: barrier
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:7:9..15
+                  items: [
+                    Index( # input.cq:7:9..15
+                      expr: <
+                        Identifier( # input.cq:7:9..10
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:7:11..14
+                          items: [
+                            IndexRange( # input.cq:7:11..14
+                              first: <
+                                IntegerLiteral( # input.cq:7:11..12
+                                  value: 0
+                                )
+                              >
+                              last: <
+                                IntegerLiteral( # input.cq:7:13..14
+                                  value: 2
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:8:1..7
+          items: [
+            Instruction( # input.cq:8:1..7
+              name: <
+                Identifier( # input.cq:8:1..2
+                  name: x
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:8:3..7
+                  items: [
+                    Index( # input.cq:8:3..7
+                      expr: <
+                        Identifier( # input.cq:8:3..4
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:8:5..6
+                          items: [
+                            IndexItem( # input.cq:8:5..6
+                              index: <
+                                IntegerLiteral( # input.cq:8:5..6
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:9:1..7
+          items: [
+            Instruction( # input.cq:9:1..7
+              name: <
+                Identifier( # input.cq:9:1..2
+                  name: x
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:9:3..7
+                  items: [
+                    Index( # input.cq:9:3..7
+                      expr: <
+                        Identifier( # input.cq:9:3..4
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:9:5..6
+                          items: [
+                            IndexItem( # input.cq:9:5..6
+                              index: <
+                                IntegerLiteral( # input.cq:9:5..6
+                                  value: 2
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/src/cqasm/tests/v1-parsing/misc/barriers-ok-1/input.cq
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-ok-1/input.cq
@@ -1,0 +1,9 @@
+version 1.0
+qubits 3
+
+x q[0]
+barrier q[0,1]
+x q[1]
+barrier q[0:2]
+x q[0]
+x q[2]

--- a/src/cqasm/tests/v1-parsing/misc/barriers-ok-1/semantic.1.0.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-ok-1/semantic.1.0.golden.txt
@@ -1,0 +1,177 @@
+SUCCESS
+Program( # input.cq:1:1..10:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: 3
+  error_model: -
+  subcircuits: [
+    Subcircuit( # input.cq:4:1..7
+      name: 
+      iterations: 1
+      bundles: [
+        Bundle( # input.cq:4:1..7
+          items: [
+            Instruction( # input.cq:4:1..7
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:4:3..7
+                  index: [
+                    ConstInt( # input.cq:4:5..6
+                      value: 0
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:5:1..15
+          items: [
+            Instruction( # input.cq:5:1..15
+              instruction: barrier(qubit reference)
+              name: barrier
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:5:9..15
+                  index: [
+                    ConstInt( # input.cq:5:11..12
+                      value: 0
+                    )
+                    ConstInt( # input.cq:5:13..14
+                      value: 1
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:6:1..7
+          items: [
+            Instruction( # input.cq:6:1..7
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:6:3..7
+                  index: [
+                    ConstInt( # input.cq:6:5..6
+                      value: 1
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:7:1..15
+          items: [
+            Instruction( # input.cq:7:1..15
+              instruction: barrier(qubit reference)
+              name: barrier
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:7:9..15
+                  index: [
+                    ConstInt( # input.cq:7:11..14
+                      value: 0
+                    )
+                    ConstInt( # input.cq:7:11..14
+                      value: 1
+                    )
+                    ConstInt( # input.cq:7:11..14
+                      value: 2
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:8:1..7
+          items: [
+            Instruction( # input.cq:8:1..7
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:8:3..7
+                  index: [
+                    ConstInt( # input.cq:8:5..6
+                      value: 0
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:9:1..7
+          items: [
+            Instruction( # input.cq:9:1..7
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:9:3..7
+                  index: [
+                    ConstInt( # input.cq:9:5..6
+                      value: 2
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+      annotations: []
+      body: -
+    )
+  ]
+  mappings: []
+  variables: []
+  api_version: 1.0
+)
+

--- a/src/cqasm/tests/v1-parsing/misc/barriers-ok-1/semantic.1.1.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-ok-1/semantic.1.1.golden.txt
@@ -1,0 +1,177 @@
+SUCCESS
+Program( # input.cq:1:1..10:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: 3
+  error_model: -
+  subcircuits: [
+    Subcircuit( # input.cq:4:1..7
+      name: 
+      iterations: 1
+      bundles: [
+        Bundle( # input.cq:4:1..7
+          items: [
+            Instruction( # input.cq:4:1..7
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:4:3..7
+                  index: [
+                    ConstInt( # input.cq:4:5..6
+                      value: 0
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:5:1..15
+          items: [
+            Instruction( # input.cq:5:1..15
+              instruction: barrier(qubit reference)
+              name: barrier
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:5:9..15
+                  index: [
+                    ConstInt( # input.cq:5:11..12
+                      value: 0
+                    )
+                    ConstInt( # input.cq:5:13..14
+                      value: 1
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:6:1..7
+          items: [
+            Instruction( # input.cq:6:1..7
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:6:3..7
+                  index: [
+                    ConstInt( # input.cq:6:5..6
+                      value: 1
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:7:1..15
+          items: [
+            Instruction( # input.cq:7:1..15
+              instruction: barrier(qubit reference)
+              name: barrier
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:7:9..15
+                  index: [
+                    ConstInt( # input.cq:7:11..14
+                      value: 0
+                    )
+                    ConstInt( # input.cq:7:11..14
+                      value: 1
+                    )
+                    ConstInt( # input.cq:7:11..14
+                      value: 2
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:8:1..7
+          items: [
+            Instruction( # input.cq:8:1..7
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:8:3..7
+                  index: [
+                    ConstInt( # input.cq:8:5..6
+                      value: 0
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:9:1..7
+          items: [
+            Instruction( # input.cq:9:1..7
+              instruction: x(qubit reference)
+              name: x
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:9:3..7
+                  index: [
+                    ConstInt( # input.cq:9:5..6
+                      value: 2
+                    )
+                  ]
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+      annotations: []
+      body: -
+    )
+  ]
+  mappings: []
+  variables: []
+  api_version: 1.1
+)
+

--- a/src/cqasm/tests/v1-parsing/misc/barriers-ok-1/semantic.1.2.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/barriers-ok-1/semantic.1.2.golden.txt
@@ -1,0 +1,181 @@
+SUCCESS
+Program( # input.cq:1:1..10:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: 3
+  error_model: -
+  subcircuits: [
+    Subcircuit( # input.cq:4:1..7
+      name: 
+      iterations: 1
+      bundles: []
+      annotations: []
+      body: <
+        Block( # input.cq:4:1..9:15
+          statements: [
+            BundleExt( # input.cq:4:1..7
+              items: [
+                Instruction( # input.cq:4:1..7
+                  instruction: x(qubit reference)
+                  name: x
+                  condition: <
+                    ConstBool(
+                      value: 1
+                    )
+                  >
+                  operands: [
+                    QubitRefs( # input.cq:4:3..7
+                      index: [
+                        ConstInt( # input.cq:4:5..6
+                          value: 0
+                        )
+                      ]
+                    )
+                  ]
+                  annotations: []
+                )
+              ]
+              annotations: []
+            )
+            BundleExt( # input.cq:5:1..15
+              items: [
+                Instruction( # input.cq:5:1..15
+                  instruction: barrier(qubit reference)
+                  name: barrier
+                  condition: <
+                    ConstBool(
+                      value: 1
+                    )
+                  >
+                  operands: [
+                    QubitRefs( # input.cq:5:9..15
+                      index: [
+                        ConstInt( # input.cq:5:11..12
+                          value: 0
+                        )
+                        ConstInt( # input.cq:5:13..14
+                          value: 1
+                        )
+                      ]
+                    )
+                  ]
+                  annotations: []
+                )
+              ]
+              annotations: []
+            )
+            BundleExt( # input.cq:6:1..7
+              items: [
+                Instruction( # input.cq:6:1..7
+                  instruction: x(qubit reference)
+                  name: x
+                  condition: <
+                    ConstBool(
+                      value: 1
+                    )
+                  >
+                  operands: [
+                    QubitRefs( # input.cq:6:3..7
+                      index: [
+                        ConstInt( # input.cq:6:5..6
+                          value: 1
+                        )
+                      ]
+                    )
+                  ]
+                  annotations: []
+                )
+              ]
+              annotations: []
+            )
+            BundleExt( # input.cq:7:1..15
+              items: [
+                Instruction( # input.cq:7:1..15
+                  instruction: barrier(qubit reference)
+                  name: barrier
+                  condition: <
+                    ConstBool(
+                      value: 1
+                    )
+                  >
+                  operands: [
+                    QubitRefs( # input.cq:7:9..15
+                      index: [
+                        ConstInt( # input.cq:7:11..14
+                          value: 0
+                        )
+                        ConstInt( # input.cq:7:11..14
+                          value: 1
+                        )
+                        ConstInt( # input.cq:7:11..14
+                          value: 2
+                        )
+                      ]
+                    )
+                  ]
+                  annotations: []
+                )
+              ]
+              annotations: []
+            )
+            BundleExt( # input.cq:8:1..7
+              items: [
+                Instruction( # input.cq:8:1..7
+                  instruction: x(qubit reference)
+                  name: x
+                  condition: <
+                    ConstBool(
+                      value: 1
+                    )
+                  >
+                  operands: [
+                    QubitRefs( # input.cq:8:3..7
+                      index: [
+                        ConstInt( # input.cq:8:5..6
+                          value: 0
+                        )
+                      ]
+                    )
+                  ]
+                  annotations: []
+                )
+              ]
+              annotations: []
+            )
+            BundleExt( # input.cq:9:1..7
+              items: [
+                Instruction( # input.cq:9:1..7
+                  instruction: x(qubit reference)
+                  name: x
+                  condition: <
+                    ConstBool(
+                      value: 1
+                    )
+                  >
+                  operands: [
+                    QubitRefs( # input.cq:9:3..7
+                      index: [
+                        ConstInt( # input.cq:9:5..6
+                          value: 2
+                        )
+                      ]
+                    )
+                  ]
+                  annotations: []
+                )
+              ]
+              annotations: []
+            )
+          ]
+        )
+      >
+    )
+  ]
+  mappings: []
+  variables: []
+  api_version: 1.2
+)
+

--- a/src/tests/cpp/barriers.cpp
+++ b/src/tests/cpp/barriers.cpp
@@ -1,0 +1,32 @@
+/** This test is for barriers qasm file in the paper **/
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+// [[noreturn]] completely breaks MSVC 2015, and is basically unnecessary
+#ifdef _MSC_VER
+#define DOCTEST_NORETURN
+#endif
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include "qasm_semantic.hpp"
+#include "doctest/doctest.h"
+
+TEST_CASE("Test for the barriers.qasm file")
+{
+    #if YYDEBUG == 1
+    extern int yydebug;
+    yydebug = 1;
+    #endif
+
+    // open a file handle to a particular file:
+    FILE *myfile = fopen("barriers.qasm", "r");
+
+    compiler::QasmSemanticChecker sm(myfile);
+
+    auto qasm_representation = sm.getQasmRepresentation();
+
+    int result = sm.parseResult();
+
+    CHECK(result == 0);   // Stop here if it fails.
+}

--- a/src/tests/test_data/barriers.qasm
+++ b/src/tests/test_data/barriers.qasm
@@ -1,0 +1,10 @@
+version 1.0
+#define a quantum register of 3 qubits
+qubits 3
+
+x q[0]
+barrier q[0,1]
+x q[1]
+barrier q[0:2]
+x q[0]
+x q[2]


### PR DESCRIPTION
Added unit tests for the barriers instruction that was added to cQASM v1.0 default instruction set.

Note that we currently test for `barrier q[0], q[1]` failing, as it should given its current implementation using a single qubit gate (type param `Q`). However, the original requirement was for also this syntax to work, although `barrier q[0,1]` is recommened/preferred.