### PR TITLE
Replace 'wait i' with 'wait q[..],i' syntax v1.0

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,7 +41,7 @@ html_extra_path = ['../doxygen']
 # -- Project information -----------------------------------------------------
 
 project = 'libqasm'
-copyright = '2020, QuTech, TU Delft'
+copyright = '2022, QuTech, TU Delft'
 author = 'QuTech, TU Delft'
 
 # The short X.Y version

--- a/doc/source/cq1-instructions.rst
+++ b/doc/source/cq1-instructions.rst
@@ -279,8 +279,8 @@ Applies a controlled phase (controlled Z) gate with the given rotation angle in
 radians on the given qubit pair. The first qubit is the control qubit, the
 second is the target.
 
-``cr <qubit>, <qubit>, <k>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``crk <qubit>, <qubit>, <k>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Applies a controlled phase (controlled Z) gate with the given rotation angle on
 the given qubit pair. The rotation angle is π/2\ :sup:`k` radians. The first

--- a/doc/source/cq1-instructions.rst
+++ b/doc/source/cq1-instructions.rst
@@ -369,12 +369,16 @@ example:
 
 This instruction cannot share a bundle with other instructions.
 
-``wait <qubit-ref>, <integer>``
+``wait <qubit>, <integer>``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Wait for all previous instructions involving the specified qubit(s) to finish,
-then wait the given number of cycles before starting the next bundle.
-In essence, this acts as a no-op instruction with the specified duration in cycles.
+For each of the specified qubits, wait independently for all previous instructions
+involving the specified qubit to finish, and then wait at least the given number
+of cycles before starting a next instruction involving the specified qubit.
+In essence, this acts as a no-op instruction for the specified qubit with the
+specified duration in cycles. The individual waits on each of the qubits
+are independent of each other, following the regular single-gate-multiple-qubit
+rules.
 
 .. note::
 
@@ -402,7 +406,7 @@ In essence, this acts as a no-op instruction with the specified duration in cycl
         skip 2       # starts in cycle 2
         z q[0]       # starts in cycle 4
 
-``barrier <qubit-ref>``
+``barrier <qubit>``
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Waits for all operations on the given qubit(s) (using single-gate multiple-qubit

--- a/doc/source/cq1-instructions.rst
+++ b/doc/source/cq1-instructions.rst
@@ -370,7 +370,7 @@ example:
 This instruction cannot share a bundle with other instructions.
 
 ``wait <qubit>, <integer>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For each of the specified qubits, wait independently for all previous instructions
 involving the specified qubit to finish, and then wait at least the given number
@@ -407,7 +407,7 @@ rules.
         z q[0]       # starts in cycle 4
 
 ``barrier <qubit>``
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 Waits for all operations on the given qubit(s) (using single-gate multiple-qubit
 notation) to finish, before advancing to the next instruction.

--- a/doc/source/cq1-instructions.rst
+++ b/doc/source/cq1-instructions.rst
@@ -369,13 +369,12 @@ example:
 
 This instruction cannot share a bundle with other instructions.
 
-``wait <integer>``
-~~~~~~~~~~~~~~~~~~
+``wait <qubit-ref>, <integer>``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Wait for all previous instructions to finish, then wait the given number of
-cycles before starting the next bundle. Also known as a barrier. In essence,
-this acts as a no-op instruction with the specified duration in cycles, that
-requires access to all qubits, bits, and variables.
+Wait for all previous instructions involving the specified qubit(s) to finish,
+then wait the given number of cycles before starting the next bundle.
+In essence, this acts as a no-op instruction with the specified duration in cycles.
 
 .. note::
 
@@ -391,17 +390,17 @@ requires access to all qubits, bits, and variables.
     .. code:: text
 
         x q[0]
-        wait 3
-        x q[1]
+        wait q[0], 3
+        z q[0]
 
     may compile into
 
     .. code:: text
 
-        x q[0]  # starts in cycle 0
-        wait 3  # starts in cycle 1
-        skip 2  # starts in cycle 2
-        x q[1]  # starts in cycle 4
+        x q[0]       # starts in cycle 0
+        wait q[0],3  # starts in cycle 1
+        skip 2       # starts in cycle 2
+        z q[0]       # starts in cycle 4
 
 ``barrier <qubit-ref>``
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/cq1-instructions.rst
+++ b/doc/source/cq1-instructions.rst
@@ -409,8 +409,21 @@ rules.
 ``barrier <qubit>``
 ~~~~~~~~~~~~~~~~~~~
 
-Waits for all operations on the given qubit(s) (using single-gate multiple-qubit
-notation) to finish, before advancing to the next instruction.
+Waits for all operations on all given qubit(s) to finish, before advancing to the
+next instruction. For the qubit argument of barrier, single-gate multiple-qubit notation
+is used.
+
+.. note::
+
+    While the single-gate-multiple-qubit notation is used to specify multiple qubits
+    involved in the barrier gate, the individual qubits should not broadcast to
+    individual barrier gates. For example:
+
+    .. code:: text
+
+        barrier q[0:3]
+        # should not broadcast to
+        barrier q[0] | barrier q[1] | barrier q[2] | barrier q[3]
 
 ``not <bit-ref>``
 ~~~~~~~~~~~~~~~~~

--- a/src/cqasm/src/cqasm-v1.cpp
+++ b/src/cqasm/src/cqasm-v1.cpp
@@ -108,7 +108,7 @@ analyzer::Analyzer default_analyzer(const std::string &api_version) {
     analyzer.register_instruction("display_binary", "", false, false);
     analyzer.register_instruction("display_binary", "B", false, false);
     analyzer.register_instruction("skip", "i", false, false);
-    analyzer.register_instruction("wait", "i", false, false);
+    analyzer.register_instruction("wait", "Qi", false, false);
     analyzer.register_instruction("barrier", "Q", false, false);
     analyzer.register_instruction("reset-averaging", "", false, false);
     analyzer.register_instruction("reset-averaging", "Q", false, false);

--- a/src/cqasm/tests/v1-parsing.cpp
+++ b/src/cqasm/tests/v1-parsing.cpp
@@ -132,7 +132,7 @@ public:
             analyzer.register_instruction("display_binary", "", false, false);
             analyzer.register_instruction("display_binary", "B", false, false);
             analyzer.register_instruction("skip", "i", false, false);
-            analyzer.register_instruction("wait", "i", false, false);
+            analyzer.register_instruction("wait", "Qi", false, false);
             analyzer.register_instruction("barrier", "Q", false, false);
             analyzer.register_instruction("reset-averaging", "", false, false);
             analyzer.register_instruction("reset-averaging", "Q", false, false);

--- a/src/cqasm/tests/v1-parsing/misc/wait-not-ok-1/ast.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/wait-not-ok-1/ast.golden.txt
@@ -1,0 +1,43 @@
+SUCCESS
+Program( # input.cq:1:1..5:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: <
+    IntegerLiteral( # input.cq:2:8..9
+      value: 2
+    )
+  >
+  statements: <
+    StatementList( # input.cq:2:1..5:7
+      items: [
+        Bundle( # input.cq:4:1..7
+          items: [
+            Instruction( # input.cq:4:1..7
+              name: <
+                Identifier( # input.cq:4:1..5
+                  name: wait
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:4:6..7
+                  items: [
+                    IntegerLiteral( # input.cq:4:6..7
+                      value: 1
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/src/cqasm/tests/v1-parsing/misc/wait-not-ok-1/input.cq
+++ b/src/cqasm/tests/v1-parsing/misc/wait-not-ok-1/input.cq
@@ -1,0 +1,4 @@
+version 1.0
+qubits 2
+
+wait 1

--- a/src/cqasm/tests/v1-parsing/misc/wait-not-ok-1/semantic.1.0.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/wait-not-ok-1/semantic.1.0.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:4:1..7: failed to resolve overload for wait with argument pack (int)

--- a/src/cqasm/tests/v1-parsing/misc/wait-not-ok-1/semantic.1.1.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/wait-not-ok-1/semantic.1.1.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:4:1..7: failed to resolve overload for wait with argument pack (int)

--- a/src/cqasm/tests/v1-parsing/misc/wait-not-ok-1/semantic.1.2.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/wait-not-ok-1/semantic.1.2.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:4:1..7: failed to resolve overload for wait with argument pack (int)

--- a/src/cqasm/tests/v1-parsing/misc/wait-ok-1/ast.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/wait-ok-1/ast.golden.txt
@@ -1,0 +1,272 @@
+SUCCESS
+Program( # input.cq:1:1..11:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: <
+    IntegerLiteral( # input.cq:2:8..9
+      value: 4
+    )
+  >
+  statements: <
+    StatementList( # input.cq:2:1..11:20
+      items: [
+        Mapping( # input.cq:4:1..14
+          alias: <
+            Identifier( # input.cq:4:12..14
+              name: q2
+            )
+          >
+          expr: <
+            Index( # input.cq:4:5..9
+              expr: <
+                Identifier( # input.cq:4:5..6
+                  name: q
+                )
+              >
+              indices: <
+                IndexList( # input.cq:4:7..8
+                  items: [
+                    IndexItem( # input.cq:4:7..8
+                      index: <
+                        IntegerLiteral( # input.cq:4:7..8
+                          value: 2
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
+            )
+          >
+          annotations: []
+        )
+        Bundle( # input.cq:6:1..13
+          items: [
+            Instruction( # input.cq:6:1..13
+              name: <
+                Identifier( # input.cq:6:1..5
+                  name: wait
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:6:6..13
+                  items: [
+                    Index( # input.cq:6:6..10
+                      expr: <
+                        Identifier( # input.cq:6:6..7
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:6:8..9
+                          items: [
+                            IndexItem( # input.cq:6:8..9
+                              index: <
+                                IntegerLiteral( # input.cq:6:8..9
+                                  value: 0
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                    IntegerLiteral( # input.cq:6:12..13
+                      value: 1
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:7:1..12
+          items: [
+            Instruction( # input.cq:7:1..12
+              name: <
+                Identifier( # input.cq:7:1..5
+                  name: wait
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:7:6..12
+                  items: [
+                    Identifier( # input.cq:7:6..8
+                      name: q2
+                    )
+                    IntegerLiteral( # input.cq:7:10..12
+                      value: 10
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:8:1..17
+          items: [
+            Instruction( # input.cq:8:1..17
+              name: <
+                Identifier( # input.cq:8:1..5
+                  name: wait
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:8:6..17
+                  items: [
+                    Index( # input.cq:8:6..12
+                      expr: <
+                        Identifier( # input.cq:8:6..7
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:8:8..11
+                          items: [
+                            IndexRange( # input.cq:8:8..11
+                              first: <
+                                IntegerLiteral( # input.cq:8:8..9
+                                  value: 1
+                                )
+                              >
+                              last: <
+                                IntegerLiteral( # input.cq:8:10..11
+                                  value: 2
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                    IntegerLiteral( # input.cq:8:14..17
+                      value: 100
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:9:1..15
+          items: [
+            Instruction( # input.cq:9:1..15
+              name: <
+                Identifier( # input.cq:9:1..5
+                  name: wait
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:9:6..15
+                  items: [
+                    Index( # input.cq:9:6..12
+                      expr: <
+                        Identifier( # input.cq:9:6..7
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:9:8..11
+                          items: [
+                            IndexRange( # input.cq:9:8..11
+                              first: <
+                                IntegerLiteral( # input.cq:9:8..9
+                                  value: 0
+                                )
+                              >
+                              last: <
+                                IntegerLiteral( # input.cq:9:10..11
+                                  value: 2
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                    IntegerLiteral( # input.cq:9:14..15
+                      value: 0
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:10:1..20
+          items: [
+            Instruction( # input.cq:10:1..20
+              name: <
+                Identifier( # input.cq:10:1..5
+                  name: wait
+                )
+              >
+              condition: -
+              operands: <
+                ExpressionList( # input.cq:10:6..20
+                  items: [
+                    Index( # input.cq:10:6..14
+                      expr: <
+                        Identifier( # input.cq:10:6..7
+                          name: q
+                        )
+                      >
+                      indices: <
+                        IndexList( # input.cq:10:8..13
+                          items: [
+                            IndexItem( # input.cq:10:8..9
+                              index: <
+                                IntegerLiteral( # input.cq:10:8..9
+                                  value: 0
+                                )
+                              >
+                            )
+                            IndexItem( # input.cq:10:10..11
+                              index: <
+                                IntegerLiteral( # input.cq:10:10..11
+                                  value: 2
+                                )
+                              >
+                            )
+                            IndexItem( # input.cq:10:12..13
+                              index: <
+                                IntegerLiteral( # input.cq:10:12..13
+                                  value: 3
+                                )
+                              >
+                            )
+                          ]
+                        )
+                      >
+                    )
+                    IntegerLiteral( # input.cq:10:16..20
+                      value: 1000
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/src/cqasm/tests/v1-parsing/misc/wait-ok-1/input.cq
+++ b/src/cqasm/tests/v1-parsing/misc/wait-ok-1/input.cq
@@ -1,0 +1,10 @@
+version 1.0
+qubits 4
+
+map q[2] , q2
+
+wait q[0], 1
+wait q2, 10
+wait q[1:2], 100
+wait q[0:2], 0
+wait q[0,2,3], 1000

--- a/src/cqasm/tests/v1-parsing/misc/wait-ok-1/semantic.1.0.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/wait-ok-1/semantic.1.0.golden.txt
@@ -1,0 +1,188 @@
+SUCCESS
+Program( # input.cq:1:1..11:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: 4
+  error_model: -
+  subcircuits: [
+    Subcircuit( # input.cq:6:1..13
+      name: 
+      iterations: 1
+      bundles: [
+        Bundle( # input.cq:6:1..13
+          items: [
+            Instruction( # input.cq:6:1..13
+              instruction: wait(qubit reference, int)
+              name: wait
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:6:6..10
+                  index: [
+                    ConstInt( # input.cq:6:8..9
+                      value: 0
+                    )
+                  ]
+                )
+                ConstInt( # input.cq:6:12..13
+                  value: 1
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:7:1..12
+          items: [
+            Instruction( # input.cq:7:1..12
+              instruction: wait(qubit reference, int)
+              name: wait
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:7:6..8
+                  index: [
+                    ConstInt( # input.cq:4:7..8
+                      value: 2
+                    )
+                  ]
+                )
+                ConstInt( # input.cq:7:10..12
+                  value: 10
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:8:1..17
+          items: [
+            Instruction( # input.cq:8:1..17
+              instruction: wait(qubit reference, int)
+              name: wait
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:8:6..12
+                  index: [
+                    ConstInt( # input.cq:8:8..11
+                      value: 1
+                    )
+                    ConstInt( # input.cq:8:8..11
+                      value: 2
+                    )
+                  ]
+                )
+                ConstInt( # input.cq:8:14..17
+                  value: 100
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:9:1..15
+          items: [
+            Instruction( # input.cq:9:1..15
+              instruction: wait(qubit reference, int)
+              name: wait
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:9:6..12
+                  index: [
+                    ConstInt( # input.cq:9:8..11
+                      value: 0
+                    )
+                    ConstInt( # input.cq:9:8..11
+                      value: 1
+                    )
+                    ConstInt( # input.cq:9:8..11
+                      value: 2
+                    )
+                  ]
+                )
+                ConstInt( # input.cq:9:14..15
+                  value: 0
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:10:1..20
+          items: [
+            Instruction( # input.cq:10:1..20
+              instruction: wait(qubit reference, int)
+              name: wait
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:10:6..14
+                  index: [
+                    ConstInt( # input.cq:10:8..9
+                      value: 0
+                    )
+                    ConstInt( # input.cq:10:10..11
+                      value: 2
+                    )
+                    ConstInt( # input.cq:10:12..13
+                      value: 3
+                    )
+                  ]
+                )
+                ConstInt( # input.cq:10:16..20
+                  value: 1000
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+      annotations: []
+      body: -
+    )
+  ]
+  mappings: [
+    Mapping( # input.cq:4:1..14
+      name: q2
+      value: <
+        QubitRefs( # input.cq:4:5..9
+          index: [
+            ConstInt( # input.cq:4:7..8
+              value: 2
+            )
+          ]
+        )
+      >
+      annotations: []
+    )
+  ]
+  variables: []
+  api_version: 1.0
+)
+

--- a/src/cqasm/tests/v1-parsing/misc/wait-ok-1/semantic.1.1.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/wait-ok-1/semantic.1.1.golden.txt
@@ -1,0 +1,188 @@
+SUCCESS
+Program( # input.cq:1:1..11:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: 4
+  error_model: -
+  subcircuits: [
+    Subcircuit( # input.cq:6:1..13
+      name: 
+      iterations: 1
+      bundles: [
+        Bundle( # input.cq:6:1..13
+          items: [
+            Instruction( # input.cq:6:1..13
+              instruction: wait(qubit reference, int)
+              name: wait
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:6:6..10
+                  index: [
+                    ConstInt( # input.cq:6:8..9
+                      value: 0
+                    )
+                  ]
+                )
+                ConstInt( # input.cq:6:12..13
+                  value: 1
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:7:1..12
+          items: [
+            Instruction( # input.cq:7:1..12
+              instruction: wait(qubit reference, int)
+              name: wait
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:7:6..8
+                  index: [
+                    ConstInt( # input.cq:4:7..8
+                      value: 2
+                    )
+                  ]
+                )
+                ConstInt( # input.cq:7:10..12
+                  value: 10
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:8:1..17
+          items: [
+            Instruction( # input.cq:8:1..17
+              instruction: wait(qubit reference, int)
+              name: wait
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:8:6..12
+                  index: [
+                    ConstInt( # input.cq:8:8..11
+                      value: 1
+                    )
+                    ConstInt( # input.cq:8:8..11
+                      value: 2
+                    )
+                  ]
+                )
+                ConstInt( # input.cq:8:14..17
+                  value: 100
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:9:1..15
+          items: [
+            Instruction( # input.cq:9:1..15
+              instruction: wait(qubit reference, int)
+              name: wait
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:9:6..12
+                  index: [
+                    ConstInt( # input.cq:9:8..11
+                      value: 0
+                    )
+                    ConstInt( # input.cq:9:8..11
+                      value: 1
+                    )
+                    ConstInt( # input.cq:9:8..11
+                      value: 2
+                    )
+                  ]
+                )
+                ConstInt( # input.cq:9:14..15
+                  value: 0
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+        Bundle( # input.cq:10:1..20
+          items: [
+            Instruction( # input.cq:10:1..20
+              instruction: wait(qubit reference, int)
+              name: wait
+              condition: <
+                ConstBool(
+                  value: 1
+                )
+              >
+              operands: [
+                QubitRefs( # input.cq:10:6..14
+                  index: [
+                    ConstInt( # input.cq:10:8..9
+                      value: 0
+                    )
+                    ConstInt( # input.cq:10:10..11
+                      value: 2
+                    )
+                    ConstInt( # input.cq:10:12..13
+                      value: 3
+                    )
+                  ]
+                )
+                ConstInt( # input.cq:10:16..20
+                  value: 1000
+                )
+              ]
+              annotations: []
+            )
+          ]
+          annotations: []
+        )
+      ]
+      annotations: []
+      body: -
+    )
+  ]
+  mappings: [
+    Mapping( # input.cq:4:1..14
+      name: q2
+      value: <
+        QubitRefs( # input.cq:4:5..9
+          index: [
+            ConstInt( # input.cq:4:7..8
+              value: 2
+            )
+          ]
+        )
+      >
+      annotations: []
+    )
+  ]
+  variables: []
+  api_version: 1.1
+)
+

--- a/src/cqasm/tests/v1-parsing/misc/wait-ok-1/semantic.1.2.golden.txt
+++ b/src/cqasm/tests/v1-parsing/misc/wait-ok-1/semantic.1.2.golden.txt
@@ -1,0 +1,192 @@
+SUCCESS
+Program( # input.cq:1:1..11:1
+  version: <
+    Version( # input.cq:1:9..12
+      items: 1.0
+    )
+  >
+  num_qubits: 4
+  error_model: -
+  subcircuits: [
+    Subcircuit( # input.cq:6:1..13
+      name: 
+      iterations: 1
+      bundles: []
+      annotations: []
+      body: <
+        Block( # input.cq:6:1..10:20
+          statements: [
+            BundleExt( # input.cq:6:1..13
+              items: [
+                Instruction( # input.cq:6:1..13
+                  instruction: wait(qubit reference, int)
+                  name: wait
+                  condition: <
+                    ConstBool(
+                      value: 1
+                    )
+                  >
+                  operands: [
+                    QubitRefs( # input.cq:6:6..10
+                      index: [
+                        ConstInt( # input.cq:6:8..9
+                          value: 0
+                        )
+                      ]
+                    )
+                    ConstInt( # input.cq:6:12..13
+                      value: 1
+                    )
+                  ]
+                  annotations: []
+                )
+              ]
+              annotations: []
+            )
+            BundleExt( # input.cq:7:1..12
+              items: [
+                Instruction( # input.cq:7:1..12
+                  instruction: wait(qubit reference, int)
+                  name: wait
+                  condition: <
+                    ConstBool(
+                      value: 1
+                    )
+                  >
+                  operands: [
+                    QubitRefs( # input.cq:7:6..8
+                      index: [
+                        ConstInt( # input.cq:4:7..8
+                          value: 2
+                        )
+                      ]
+                    )
+                    ConstInt( # input.cq:7:10..12
+                      value: 10
+                    )
+                  ]
+                  annotations: []
+                )
+              ]
+              annotations: []
+            )
+            BundleExt( # input.cq:8:1..17
+              items: [
+                Instruction( # input.cq:8:1..17
+                  instruction: wait(qubit reference, int)
+                  name: wait
+                  condition: <
+                    ConstBool(
+                      value: 1
+                    )
+                  >
+                  operands: [
+                    QubitRefs( # input.cq:8:6..12
+                      index: [
+                        ConstInt( # input.cq:8:8..11
+                          value: 1
+                        )
+                        ConstInt( # input.cq:8:8..11
+                          value: 2
+                        )
+                      ]
+                    )
+                    ConstInt( # input.cq:8:14..17
+                      value: 100
+                    )
+                  ]
+                  annotations: []
+                )
+              ]
+              annotations: []
+            )
+            BundleExt( # input.cq:9:1..15
+              items: [
+                Instruction( # input.cq:9:1..15
+                  instruction: wait(qubit reference, int)
+                  name: wait
+                  condition: <
+                    ConstBool(
+                      value: 1
+                    )
+                  >
+                  operands: [
+                    QubitRefs( # input.cq:9:6..12
+                      index: [
+                        ConstInt( # input.cq:9:8..11
+                          value: 0
+                        )
+                        ConstInt( # input.cq:9:8..11
+                          value: 1
+                        )
+                        ConstInt( # input.cq:9:8..11
+                          value: 2
+                        )
+                      ]
+                    )
+                    ConstInt( # input.cq:9:14..15
+                      value: 0
+                    )
+                  ]
+                  annotations: []
+                )
+              ]
+              annotations: []
+            )
+            BundleExt( # input.cq:10:1..20
+              items: [
+                Instruction( # input.cq:10:1..20
+                  instruction: wait(qubit reference, int)
+                  name: wait
+                  condition: <
+                    ConstBool(
+                      value: 1
+                    )
+                  >
+                  operands: [
+                    QubitRefs( # input.cq:10:6..14
+                      index: [
+                        ConstInt( # input.cq:10:8..9
+                          value: 0
+                        )
+                        ConstInt( # input.cq:10:10..11
+                          value: 2
+                        )
+                        ConstInt( # input.cq:10:12..13
+                          value: 3
+                        )
+                      ]
+                    )
+                    ConstInt( # input.cq:10:16..20
+                      value: 1000
+                    )
+                  ]
+                  annotations: []
+                )
+              ]
+              annotations: []
+            )
+          ]
+        )
+      >
+    )
+  ]
+  mappings: [
+    Mapping( # input.cq:4:1..14
+      name: q2
+      value: <
+        QubitRefs( # input.cq:4:5..9
+          index: [
+            ConstInt( # input.cq:4:7..8
+              value: 2
+            )
+          ]
+        )
+      >
+      annotations: []
+    )
+  ]
+  variables: []
+  api_version: 1.2
+)
+

--- a/src/library/qasm_ast.hpp
+++ b/src/library/qasm_ast.hpp
@@ -143,6 +143,17 @@ namespace compiler
                 type_ = toLowerCase(type);
             }
 
+            Operation(const std::string type, const int waitInt, Qubits qubits_involved)
+            : qubits_ (qubits_involved),
+              rotation_angle_ (std::numeric_limits<double>::max()), bit_controlled_(false)
+            // Single qubit wait
+            // NOTE to avoid ambigious overload with single qubit rotation (double),
+            // the int is the first argument (FIXME?)
+            {
+                type_ = toLowerCase(type);
+                wait_time_ = waitInt;
+            }
+
             Operation(const std::string type, Qubits qubit_pair1, std::string axis1, Qubits qubit_pair2, std::string axis2)
             : rotation_angle_ (std::numeric_limits<double>::max()), bit_controlled_(false)
             // Measure parity operation
@@ -372,6 +383,7 @@ namespace compiler
                 else if (type_ == "wait")
                 {
                     std::cout << std::endl;
+                    // TODO also print qubits
                     std::cout << "Wait time (integer) = " << getWaitTime() << std::endl;
                 }
                 else if ( (type_ == "display") || (type_ == "display_binary") )

--- a/src/library/qasm_ast.hpp
+++ b/src/library/qasm_ast.hpp
@@ -143,15 +143,13 @@ namespace compiler
                 type_ = toLowerCase(type);
             }
 
-            Operation(const std::string type, const int waitInt, Qubits qubits_involved)
+            Operation(const std::string type, Qubits qubits_involved, const int wait_int)
             : qubits_ (qubits_involved),
               rotation_angle_ (std::numeric_limits<double>::max()), bit_controlled_(false)
             // Single qubit wait
-            // NOTE to avoid ambigious overload with single qubit rotation (double),
-            // the int is the first argument (FIXME?)
             {
                 type_ = toLowerCase(type);
-                wait_time_ = waitInt;
+                wait_time_ = wait_int;
             }
 
             Operation(const std::string type, Qubits qubit_pair1, std::string axis1, Qubits qubit_pair2, std::string axis2)
@@ -171,12 +169,12 @@ namespace compiler
                 all_qubits_bits_ = true;
             }
 
-            Operation(const std::string type, const int waitInt)
+            Operation(const std::string type, const int wait_int)
             : rotation_angle_ (std::numeric_limits<double>::max()), bit_controlled_(false)
-            // Wait and Skip commands
+            // Skip command
             {
                 type_ = toLowerCase(type);
-                wait_time_ = waitInt;
+                wait_time_ = wait_int;
             }
 
             Operation(const std::string type, const Bits display_bits)
@@ -255,15 +253,15 @@ namespace compiler
                     switch(qubit_pair_index){
                         case 1: return two_qubit_pairs_.first; break;
                         case 2: return two_qubit_pairs_.second; break;
-                        default: throw std::runtime_error( std::string("Accessing qubit pair ") 
-                                              + std::to_string(qubit_pair_index) 
+                        default: throw std::runtime_error( std::string("Accessing qubit pair ")
+                                              + std::to_string(qubit_pair_index)
                                               + std::string(" on operation ") + type_ ); return qubits_;
                     }
                 }
                 else
                 {
-                    throw std::runtime_error( std::string("Accessing qubit pair ") 
-                                              + std::to_string(qubit_pair_index) 
+                    throw std::runtime_error( std::string("Accessing qubit pair ")
+                                              + std::to_string(qubit_pair_index)
                                               + std::string(" on operation ") + type_ );
                     return qubits_;
                 }
@@ -383,7 +381,7 @@ namespace compiler
                 else if (type_ == "wait")
                 {
                     std::cout << std::endl;
-                    // TODO also print qubits
+                    getQubitsInvolved().printMembers();
                     std::cout << "Wait time (integer) = " << getWaitTime() << std::endl;
                 }
                 else if ( (type_ == "display") || (type_ == "display_binary") )

--- a/src/library/qasm_new_to_old.hpp
+++ b/src/library/qasm_new_to_old.hpp
@@ -26,6 +26,7 @@ enum class ParameterType {
     NoArg,
     SingleBit,
     SingleQubit,
+    SingleQubitInt,
     SingleQubitReal,
     SingleQubitMatrix,
     TwoQubit,
@@ -89,6 +90,13 @@ static Operation *convert_instruction(const cqasm::semantic::Instruction &instru
         case ParameterType::SingleQubit:
             op = new Operation(
                 instruction.instruction->name,
+                Qubits(convert_indices(instruction.operands[0]->as_qubit_refs()->index))
+            );
+            break;
+        case ParameterType::SingleQubitInt:
+            op = new Operation(
+                instruction.instruction->name,
+                instruction.operands[1]->as_const_int()->value,
                 Qubits(convert_indices(instruction.operands[0]->as_qubit_refs()->index))
             );
             break;
@@ -272,7 +280,7 @@ static void handle_parse_result(QasmRepresentation &qasm, cqasm::parser::ParseRe
     REG(NoArg, "display_binary", "", false, false);
     REG(SingleBit, "display_binary", "B", false, false);
     REG(SingleInt, "skip", "i", false, false);
-    REG(SingleInt, "wait", "i", false, false);
+    REG(SingleQubitInt, "wait", "Qi", false, false);
     REG(SingleQubit, "barrier", "Q", false, false);
     REG(NoArg, "reset-averaging", "", false, false);
     REG(SingleQubit, "reset-averaging", "Q", false, false);

--- a/src/library/qasm_new_to_old.hpp
+++ b/src/library/qasm_new_to_old.hpp
@@ -96,15 +96,15 @@ static Operation *convert_instruction(const cqasm::semantic::Instruction &instru
         case ParameterType::SingleQubitInt:
             op = new Operation(
                 instruction.instruction->name,
-                instruction.operands[1]->as_const_int()->value,
-                Qubits(convert_indices(instruction.operands[0]->as_qubit_refs()->index))
+                Qubits(convert_indices(instruction.operands[0]->as_qubit_refs()->index)),
+                (const int)instruction.operands[1]->as_const_int()->value
             );
             break;
         case ParameterType::SingleQubitReal:
             op = new Operation(
                 instruction.instruction->name,
                 Qubits(convert_indices(instruction.operands[0]->as_qubit_refs()->index)),
-                instruction.operands[1]->as_const_real()->value
+                (const double)instruction.operands[1]->as_const_real()->value
             );
             break;
         case ParameterType::SingleQubitMatrix:

--- a/src/library/qasm_semantic.hpp
+++ b/src/library/qasm_semantic.hpp
@@ -109,9 +109,10 @@ namespace compiler
                 {
                     result = checkResetAveraging(op, linenumber);
                 }
-                else if (type_ == "skip" || type_ == "wait" || type_ == "display" || type_ == "display_binary" || type_ == "not" || type_ == "load_state")
+                //else if (type_ == "skip" || type_ == "wait" || type_ == "display" || type_ == "display_binary" || type_ == "not" || type_ == "load_state")
+                else if (type_ == "skip" || type_ == "display" || type_ == "display_binary" || type_ == "not" || type_ == "load_state")
                 {
-                    result = checkWaitDisplayNot(op, linenumber);
+                    result = checkSkipDisplayNot(op, linenumber);
                 }
                 else
                 // No other special operations. Left with single qubits
@@ -175,7 +176,7 @@ namespace compiler
                 return checkQubitList(op.getQubitsInvolved(), linenumber);
             }
 
-            int checkWaitDisplayNot(const compiler::Operation& op, int linenumber) const
+            int checkSkipDisplayNot(const compiler::Operation& op, int linenumber) const
             {
                 (void)op;
                 (void)linenumber;

--- a/src/library/qasm_semantic.hpp
+++ b/src/library/qasm_semantic.hpp
@@ -109,7 +109,6 @@ namespace compiler
                 {
                     result = checkResetAveraging(op, linenumber);
                 }
-                //else if (type_ == "skip" || type_ == "wait" || type_ == "display" || type_ == "display_binary" || type_ == "not" || type_ == "load_state")
                 else if (type_ == "skip" || type_ == "display" || type_ == "display_binary" || type_ == "not" || type_ == "load_state")
                 {
                     result = checkSkipDisplayNot(op, linenumber);

--- a/src/tests/cpp/wait.cpp
+++ b/src/tests/cpp/wait.cpp
@@ -1,0 +1,35 @@
+/** This test is for the wait qasm file.
+ *
+ * Note that this is not an example from the paper,
+ * but one added specifically to check wait are working for cQASM v1. **/
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+// [[noreturn]] completely breaks MSVC 2015, and is basically unnecessary
+#ifdef _MSC_VER
+#define DOCTEST_NORETURN
+#endif
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include "qasm_semantic.hpp"
+#include "doctest/doctest.h"
+
+TEST_CASE("Test for the wait.qasm file")
+{
+    #if YYDEBUG == 1
+    extern int yydebug;
+    yydebug = 1;
+    #endif
+
+    // open a file handle to a particular file:
+    FILE *myfile = fopen("wait.qasm", "r");
+
+    compiler::QasmSemanticChecker sm(myfile);
+
+    auto qasm_representation = sm.getQasmRepresentation();
+
+    int result = sm.parseResult();
+
+    CHECK(result == 0);   // Stop here if it fails.
+}

--- a/src/tests/test_data/qc.qasm
+++ b/src/tests/test_data/qc.qasm
@@ -36,7 +36,7 @@ map q[6] , q6
 map q[7] , q7
 
 .waits
-   wait 2
+   wait q[0:7],2
 
 .first_circuit(50)
    H q0 

--- a/src/tests/test_data/wait.qasm
+++ b/src/tests/test_data/wait.qasm
@@ -1,0 +1,11 @@
+version 1.0
+#define a quantum register of 3 qubits
+qubits 3
+
+x q[0]
+wait q[0],2
+x q[1]
+wait q[0,1],1
+x q[0]
+x q[2]
+wait q[0:2],5


### PR DESCRIPTION
This PR is part of the cQASM 1.0 multiple measurements update for Quantum Inspire, which specifies following modification to `wait` instruction.

> A wait gate may be used to explicitly tell the scheduler to idle the qubit it operates on for the given number of cycles. For example, if you'd write
> 
> ```
> prep_z q[0]
> wait q[0], 100
> measure q[0]
> ```
> 
> the measurement must start at least 100 cycles after the prep_z completes. wait q[0,1] follows the single-gate-multiple-qubit rule, expanding to wait q[0]; wait q[1]. Thus, the wait blocks are independent.

**Note that this breaks compatibility with cQASM v1.0**, which is an argument for **not** merging it into develop branch.